### PR TITLE
feat: allow QUERY http method

### DIFF
--- a/lib/paths.js
+++ b/lib/paths.js
@@ -128,7 +128,7 @@ internals.paths.prototype.build = function(routes) {
     // hapi wildcard method support
     if (routeData.method === '*') {
       // OPTIONS not supported by Swagger and HEAD not support by Hapi
-      ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].forEach(method => {
+      ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'QUERY'].forEach(method => {
         const newRoute = Hoek.clone(routeData);
         newRoute.method = method.toUpperCase();
         routesData.push(newRoute);


### PR DESCRIPTION
There's a proposed HTTP method, QUERY, that's basically GET but with a payload like POST. Hapi has support for QUERY (and other undefined methods) but Hapi-Swagger only allows a few methods. This adds QUERY to that list.

https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-02.html