### PR TITLE
fix: Don't add routes created by hapi-swagger into documentation

### DIFF
--- a/examples/group-ordered.js
+++ b/examples/group-ordered.js
@@ -1,4 +1,4 @@
-// `group.js` - how to use tag based grouping
+// `group-ordered.js` - how to use tag based grouping
 'use strict';
 
 const Blipp = require('blipp');

--- a/examples/routes-filtering.js
+++ b/examples/routes-filtering.js
@@ -1,4 +1,4 @@
-// `group.js` - how to use tag based grouping
+// `routes-filtering.js` - how to filter routes to be added to the docs
 'use strict';
 
 const Blipp = require('blipp');
@@ -76,7 +76,6 @@ const ser = async () => {
     port: 3000
   });
 
-  // Blipp and Good - Needs updating for Hapi v17.x
   await server.register([
     Inert,
     Vision,

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -67,7 +67,7 @@ filter.byTags = function (tags, routes) {
  */
 filter.byFunction = function (filterFn, routes) {
   return routes.filter((route) => {
-    if (route.path === '/documentation' || route.path.startsWith('/swagger')) {
+    if (route.realm && route.realm.plugin === 'hapi-swagger') {
       return false;
     }
 

--- a/test/unit/filter-test.js
+++ b/test/unit/filter-test.js
@@ -125,5 +125,33 @@ lab.experiment('filter', () => {
     const response = await server.inject({ method: 'GET', url: '/swagger.json' });
     expect(response.statusCode).to.equal(200);
     expect(Object.keys(response.result.paths).length).to.equal(routes.length);
+    const documentedRoutes = Object.keys(response.result.paths);
+    expect(documentedRoutes.some(route => route.includes('swagger'))).to.false();
+  });
+
+  lab.test('picks all routes if `routeTag` is set to () => true, when jsonPath is not default', async () => {
+    const jsonPath = '/testPath/swagger-test.json';
+    const server = await Helper.createServer({
+      jsonPath,
+      routeTag: () => true
+    }, routes);
+    const response = await server.inject({ method: 'GET', url: jsonPath });
+    expect(response.statusCode).to.equal(200);
+    expect(Object.keys(response.result.paths).length).to.equal(routes.length);
+    const documentedRoutes = Object.keys(response.result.paths);
+    expect(documentedRoutes.some(route => route.includes('swagger'))).to.false();
+  });
+
+  lab.test('picks all routes if `routeTag` is set to () => true, when swaggerUIPath is not default', async () => {
+    const swaggerUIPath = '/testPath';
+    const server = await Helper.createServer({
+      swaggerUIPath,
+      routeTag: () => true
+    }, routes);
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+    expect(response.statusCode).to.equal(200);
+    expect(Object.keys(response.result.paths).length).to.equal(routes.length);
+    const documentedRoutes = Object.keys(response.result.paths);
+    expect(documentedRoutes.some(route => route.includes('swagger'))).to.false();
   });
 });


### PR DESCRIPTION
I've discovered that in cases when `jsonPath` or `swaggerUIPath` options are set (differ from default values), some of the endpoints registered by `hapi-swagger` can be exposed into the OpenApi doc, which is not desirable 

By endpoints registered by `hapi-swagger` I mean `swagger.json` and all the `swagger-ui` ones. 