### PR TITLE
feat: add support for displayRequestDuration option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -458,6 +458,13 @@ declare namespace hapiswagger {
     tryItOutEnabled?: boolean;
 
     /**
+     * Controls the display of the request duration (in milliseconds) for "Try it out" requests.
+     * @default false
+     */
+    displayRequestDuration?: boolean;
+
+
+    /**
      * A declaration of the security schemes available to be used in the specification. This does not enforce the security schemes on the operations and only serves to provide the relevant details for each scheme
      */
     securityDefinitions?: { [name: string]: SecuritySchemeType };

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -256,6 +256,7 @@ internals.removeNoneSchemaOptions = function(options) {
     'routeTag',
     'validate',
     'tryItOutEnabled',
+    'displayRequestDuration'
   ].forEach(element => {
     delete out[element];
   });

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -31,4 +31,5 @@ module.exports = {
   acceptToProduce: true, // internal, NOT public
   pathReplacements: [],
   tryItOutEnabled: false,
+  displayRequestDuration: false,
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -78,6 +78,7 @@ const schema = Joi.object({
     validator: Joi.object()
   }),
   tryItOutEnabled: Joi.boolean(),
+  displayRequestDuration: Joi.boolean(),
 }).unknown();
 
 /**

--- a/optionsreference.md
+++ b/optionsreference.md
@@ -53,22 +53,23 @@
 
 > @see [swagger-ui options](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md) as reference.
 
--   `swaggerUI`: (boolean) Add files that support SwaggerUI. Only removes files if `documentationPage` is also set to false - default: `true`
--   `swaggerUIPath`: (string) The path of to all the SwaggerUI resources - default: `/swaggerui/`
--   `routesBasePath`: (string) The path to all the SwaggerUI assets endpoints. If swaggerUIPath is specified and this parameter is not, it will take swaggerUIPath value. Useful when behind a reverse proxy - default: `/swaggerui/`
--   `documentationPage`: (boolean) Add documentation page - default: `true`
--   `documentationPath`: (string) The path of the documentation page - default: `/documentation`
--   `templates`: (string) The directory path used by `hapi-swagger` and `@hapi/vision` to resolve and load the templates to render `swagger-ui` interface. The directory must contain `index.html` and `debug.html` templates. Default is `templates` directory in this package.
--   `expanded`: (string) If UI is expanded when opened. `none`, `list` or `full` - default: `list`
--   `sortTags`: (string) a sort method for `tags` i.e. groups in UI. `alpha`
+- `swaggerUI`: (boolean) Add files that support SwaggerUI. Only removes files if `documentationPage` is also set to false - default: `true`
+- `swaggerUIPath`: (string) The path of to all the SwaggerUI resources - default: `/swaggerui/`
+- `routesBasePath`: (string) The path to all the SwaggerUI assets endpoints. If swaggerUIPath is specified and this parameter is not, it will take swaggerUIPath value. Useful when behind a reverse proxy - default: `/swaggerui/`
+- `documentationPage`: (boolean) Add documentation page - default: `true`
+- `documentationPath`: (string) The path of the documentation page - default: `/documentation`
+- `templates`: (string) The directory path used by `hapi-swagger` and `@hapi/vision` to resolve and load the templates to render `swagger-ui` interface. The directory must contain `index.html` and `debug.html` templates. Default is `templates` directory in this package.
+- `expanded`: (string) If UI is expanded when opened. `none`, `list` or `full` - default: `list`
+- `sortTags`: (string) a sort method for `tags` i.e. groups in UI. `alpha`
     -   `alpha`: sort by paths alphanumerically
--   `sortEndpoints`: (string) a sort method for endpoints in UI. `alpha`, `method`, `ordered`. Default is `alpha`.
+- `sortEndpoints`: (string) a sort method for endpoints in UI. `alpha`, `method`, `ordered`. Default is `alpha`.
     -   `alpha`: sort by paths alphanumerically
     -   `method`: sort by HTTP method
     -   `ordered`: sort by `order` value of the `hapi-swagger` plugin options of the route.
--   `uiCompleteScript`: (string || object) Called when UI loads. Can be javascript string injected into the HTML (ex: `'alert("I got you !")'`) or object with `src` property (ex: `{ src: '/assets/js/doc-patch.js' }`) that can point to reference remote file. The file will be loaded on demand and appended to DOM. Default is `null`.
--   `validatorUrl`: (string || null) sets the external validating URL Can switch off by setting to `null`
--   `tryItOutEnabled`: (boolean) controls whether the "Try it out" section should be enabled by default - default: `false`
+- `uiCompleteScript`: (string || object) Called when UI loads. Can be javascript string injected into the HTML (ex: `'alert("I got you !")'`) or object with `src` property (ex: `{ src: '/assets/js/doc-patch.js' }`) that can point to reference remote file. The file will be loaded on demand and appended to DOM. Default is `null`.
+- `validatorUrl`: (string || null) sets the external validating URL Can switch off by setting to `null`
+- `tryItOutEnabled`: (boolean) controls whether the "Try it out" section should be enabled by default - default: `false`
+- `displayRequestDuration`: (boolean) controls the display of the request duration (in milliseconds) for "Try it out" requests. Default is `false`.
 
 ## Plugin Specific Route Options
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,6 +79,7 @@
             {{{ hapiSwagger.uiCompleteScript }}}
           },
           tryItOutEnabled: {{hapiSwagger.tryItOutEnabled}},
+          displayRequestDuration: {{hapiSwagger.displayRequestDuration}},
         }
 
         const ui = SwaggerUIBundle(swaggerOptions);

--- a/test/Integration/plugin-test.js
+++ b/test/Integration/plugin-test.js
@@ -473,6 +473,18 @@ lab.experiment('plugin', () => {
     expect(response.statusCode).to.equal(200);
   });
 
+  lab.test('displayRequestDuration true', async () => {
+    const server = await Helper.createServer({ displayRequestDuration: true });
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+    expect(response.statusCode).to.equal(200);
+  });
+
+  lab.test('displayRequestDuration false', async () => {
+    const server = await Helper.createServer({ displayRequestDuration: false });
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+    expect(response.statusCode).to.equal(200);
+  });
+
   lab.test('test route x-meta appears in swagger', async () => {
     const testRoutes = [
       {


### PR DESCRIPTION
Hello there 👋🏻 
I wanted to add a missing configuration option which shows the request duration on swagger-ui. This is my first pr and please feel free to guide me if i have a mistake.
Reference document : https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/