### PR TITLE
Run tests using Node.js v12 & v18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,4 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# This workflow will do a clean installation of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Node.js CI
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, windows, macos]
-        node-version: [14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR explicitly run tests on Node.js `v12` as documented in the `package.json` file and also run the tests on Node.js `v18`(upcoming LTS release)