### PR TITLE
fix: replace "Utilities.startsWith" with native "String.prototype.startsWith"

### DIFF
--- a/lib/definitions.js
+++ b/lib/definitions.js
@@ -133,7 +133,7 @@ internals.nextModelName = function(nextModelNamePrefix, currentCollection) {
   let highest = 0;
   let key;
   for (key in currentCollection) {
-    if (Utilities.startsWith(key, nextModelNamePrefix)) {
+    if (key.startsWith(nextModelNamePrefix)) {
       const num = parseInt(key.replace(nextModelNamePrefix, ''), 10) || 0;
       if (num && num > highest) {
         highest = num;

--- a/lib/group.js
+++ b/lib/group.js
@@ -61,10 +61,10 @@ group.getNameByPath = function(pathPrefixSize, basePath, path, pathReplacements)
 
   let name = pathHead.join('/');
 
-  if (basePath !== '/' && Utilities.startsWith('/' + name, basePath)) {
+  if (basePath !== '/' && `/${name}`.startsWith(basePath)) {
     name = ('/' + name).replace(basePath, '');
 
-    if (Utilities.startsWith(name, '/')) {
+    if (name.startsWith('/')) {
       name = name.replace('/', '');
     }
   }

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -390,7 +390,7 @@ internals.cleanPathParameters = function(path) {
  * @return {String}
  */
 internals.removeBasePath = function(path, basePath, pathReplacements) {
-  if (basePath !== '/' && Utilities.startsWith(path, basePath)) {
+  if (basePath !== '/' && path.startsWith(basePath)) {
     path = path.replace(basePath, '');
     path = Utilities.replaceInPath(path, ['endpoints'], pathReplacements);
   }

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -56,17 +56,6 @@ utilities.isObject = function(obj) {
   });
 
 /**
- * does string start with test, temp before native support
- *
- * @param  {String} str
- * @param  {String} str
- * @return {Boolean}
- */
-utilities.startsWith = function(str, test) {
-  return str.indexOf(test) === 0;
-};
-
-/**
  * does an object have any of its own properties
  *
  * @param  {Object} obj
@@ -229,7 +218,7 @@ utilities.findAndRenameKey = function(obj, findKey, replaceKey) {
 utilities.removeProps = function(obj, listOfProps) {
   for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
-      if (listOfProps.indexOf(key) === -1 && this.startsWith(key, 'x-') === false) {
+      if (listOfProps.indexOf(key) === -1 && key.startsWith('x-') === false) {
         delete obj[key];
         //console.log('Removed property: ' + key + ' from object: ', JSON.stringify(obj));
       }


### PR DESCRIPTION
Remove redundant implementation of `String.prototype.startsWith`.
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith), this native feature was added to Node.js `v4.0`