### PR TITLE
Refactoring func sort first item

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -127,22 +127,20 @@ utilities.first = function(array) {
 /**
  * sort array so it has a set firstItem
  *
- * @param  {Array} array
- * @param  {Object} firstItem
+ * @param  {Array<string>} array
+ * @param  {string} firstItem
  * @return {Array}
  */
 utilities.sortFirstItem = function(array, firstItem) {
-  let out = array; // todo does this corrupt the array?
-  if (firstItem) {
-    out = [firstItem];
-    array.forEach((item) => {
-      if (item !== firstItem) {
-        out.push(item);
-      }
-    });
+  const input = Hoek.clone(array);
+
+  if (!firstItem) {
+    return input;
   }
 
-  return out;
+  const filteredInput = input.filter((item) => item !== firstItem);
+
+  return [ firstItem, ...filteredInput];
 };
 
 /**

--- a/test/unit/utilities-test.js
+++ b/test/unit/utilities-test.js
@@ -114,6 +114,12 @@ lab.experiment('utilities', () => {
     expect(Utilities.findAndRenameKey(Helper.objWithNoOwnProperty(), 'x', 'y')).to.equal({});
   });
 
+  lab.test('sortFirstItem', () => {
+    expect(Utilities.sortFirstItem(['a', 'b'])).to.equal(['a', 'b']);
+    expect(Utilities.sortFirstItem(['b', 'a'], 'a')).to.equal(['a', 'b']);
+    expect(Utilities.sortFirstItem(['b', 'a', 'c'], 'a')).to.equal(['a', 'b', 'c']);
+  });
+
   lab.test('replaceValue', () => {
     expect(Utilities.replaceValue(['a', 'b'], 'a', 'c')).to.equal(['b', 'c']);
     expect(Utilities.replaceValue(['a', 'b'], null, null)).to.equal(['a', 'b']);

--- a/test/unit/utilities-test.js
+++ b/test/unit/utilities-test.js
@@ -116,8 +116,18 @@ lab.experiment('utilities', () => {
 
   lab.test('sortFirstItem', () => {
     expect(Utilities.sortFirstItem(['a', 'b'])).to.equal(['a', 'b']);
+
     expect(Utilities.sortFirstItem(['b', 'a'], 'a')).to.equal(['a', 'b']);
+    expect(Utilities.sortFirstItem(['b', 'a'], 'b')).to.equal(['b', 'a']);
+
     expect(Utilities.sortFirstItem(['b', 'a', 'c'], 'a')).to.equal(['a', 'b', 'c']);
+    expect(Utilities.sortFirstItem(['c', 'b', 'a'], 'a')).to.equal(['a', 'c', 'b']);
+
+    // Make sure that the function makes a deep copy of the input array and does not change the arguments
+    const input = ['b', 'a'];
+    const copyOfInput =  ['b', 'a'];
+    expect(Utilities.sortFirstItem(input, 'a')).to.equal(['a', 'b']);
+    expect(input).to.equal(copyOfInput);
   });
 
   lab.test('replaceValue', () => {


### PR DESCRIPTION
I made refactoring for the function `Utilities.sortFirstItem` and added correct jsDoc definition. Also, I have fixed TODO(an issue when the function possibly may modify the arguments which is bad practice). I have added the missed test for this function and made sure that the function makes a deep copy of the input array and does not change the arguments.