### PR TITLE
fix: small refactoring Utilities

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -389,19 +389,21 @@ utilities.firstBy = (function() {
  */
 utilities.createId = function(method, path) {
   const self = this;
-  if (path.indexOf('/') > -1) {
-    const pathItems = path.split('/');
-    const items = pathItems.map((item) => {
-      // replace chars such as '{'
-      item = item.replace(/[^\w\s]/gi, '');
-      return self.toTitleCase(item);
-    });
-    path = items.join('');
-  } else {
-    path = self.toTitleCase(path);
+
+  if (!path.includes('/')) {
+    return method.toLowerCase() + self.toTitleCase(path);
   }
 
-  return method.toLowerCase() + path;
+  const result = path
+    .split('/')
+    .map((item) => {
+      // replace chars such as '{'
+      const updatedItem = item.replace(/[^\w\s]/gi, '');
+      return self.toTitleCase(updatedItem);
+    })
+    .join('');
+
+  return method.toLowerCase() + result;
 };
 
 /**

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -133,20 +133,23 @@ utilities.sortFirstItem = function(array, firstItem) {
 };
 
 /**
- * replace a value in an array - does not keep order
+ * replace a value in an array and keep order
  *
- * @param  {Array} array
+ * @param  {Array} inputArray
  * @param  {Object} current
  * @param  {Object} replacement
  * @return {Array}
  */
-utilities.replaceValue = function(array, current, replacement) {
-  if (array && current && replacement) {
-    array = Hoek.clone(array);
-    if (array.indexOf(current) > -1) {
-      array.splice(array.indexOf(current), 1);
-      array.push(replacement);
-    }
+utilities.replaceValue = function(inputArray, current, replacement) {
+  if (!inputArray || !current || !replacement) {
+    return Hoek.clone(inputArray);
+  }
+
+  const array = Hoek.clone(inputArray);
+  const index = array.indexOf(current);
+
+  if (index !== -1) {
+    array.splice(index, 1, replacement);
   }
 
   return array;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -426,7 +426,7 @@ utilities.toTitleCase = function(word) {
  */
 utilities.replaceInPath = function(path, applyTo, options) {
   options.forEach(option => {
-    if (applyTo.indexOf(option.replaceIn) > -1 || option.replaceIn === 'all') {
+    if (applyTo.includes(option.replaceIn) || option.replaceIn === 'all') {
       path = path.replace(option.pattern, option.replacement);
     }
   });

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -261,7 +261,7 @@ utilities.hasJoiChildren = function(joiObj) {
  * @return {Boolean}
  */
 utilities.hasJoiMeta = function(joiObj) {
-  return utilities.isJoi(joiObj) && joiObj.$_terms.metas.length > 0 ? true : false;
+  return utilities.isJoi(joiObj) && joiObj.$_terms.metas.length > 0;
 };
 
 /**

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -411,9 +411,7 @@ utilities.createId = function(method, path) {
  * @return {string}
  */
 utilities.toTitleCase = function(word) {
-  return word.replace(/\w\S*/g, txt => {
-    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-  });
+  return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
 };
 
 /**

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -295,17 +295,17 @@ utilities.getJoiMetaProperty = function(joiObj, propertyName) {
 utilities.getJoiLabel = function(joiObj) {
   // old version
   /* $lab:coverage:off$ */
-  if (Hoek.reach(joiObj, '_settings.language.label')) {
-    return Hoek.reach(joiObj, '_settings.language.label');
+  const label = Hoek.reach(joiObj, '_settings.language.label');
+
+  if (label) {
+    return label;
   }
 
   /* $lab:coverage:on$ */
   // Joi > 10.9
-  if (Hoek.reach(joiObj, '_flags.label')) {
-    return Hoek.reach(joiObj, '_flags.label');
-  }
+  const flagsLabel = Hoek.reach(joiObj, '_flags.label');
 
-  return null;
+  return flagsLabel || null;
 };
 
 /**

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -221,7 +221,6 @@ utilities.removeProps = function(obj, listOfProps) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       if (listOfProps.indexOf(key) === -1 && key.startsWith('x-') === false) {
         delete obj[key];
-        //console.log('Removed property: ' + key + ' from object: ', JSON.stringify(obj));
       }
     }
   }

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -248,10 +248,8 @@ utilities.hasJoiChildren = function(joiObj) {
   const byId = Hoek.reach(joiObj, '_ids._byId')
   const byKey = Hoek.reach(joiObj, '_ids._byKey')
 
-  if (byId.size > 0) { return true }
-  if (byKey.size > 0) { return true }
-
-  return false
+  // TODO add tests to cover "byId.size > 0"
+  return byKey.size > 0 || byId.size > 0;
 };
 
 /**

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -303,9 +303,7 @@ utilities.getJoiLabel = function(joiObj) {
 
   /* $lab:coverage:on$ */
   // Joi > 10.9
-  const flagsLabel = Hoek.reach(joiObj, '_flags.label');
-
-  return flagsLabel || null;
+  return Hoek.reach(joiObj, '_flags.label') || null;
 };
 
 /**

--- a/test/unit/utilities-test.js
+++ b/test/unit/utilities-test.js
@@ -137,7 +137,7 @@ lab.experiment('utilities', () => {
   });
 
   lab.test('replaceValue', () => {
-    expect(Utilities.replaceValue(['a', 'b'], 'a', 'c')).to.equal(['b', 'c']);
+    expect(Utilities.replaceValue(['a', 'b'], 'a', 'c')).to.equal(['c', 'b']);
     expect(Utilities.replaceValue(['a', 'b'], null, null)).to.equal(['a', 'b']);
     expect(Utilities.replaceValue(['a', 'b'], 'a', null)).to.equal(['a', 'b']);
     expect(Utilities.replaceValue(null, null, null)).to.equal(null);

--- a/test/unit/utilities-test.js
+++ b/test/unit/utilities-test.js
@@ -114,6 +114,12 @@ lab.experiment('utilities', () => {
     expect(Utilities.findAndRenameKey(Helper.objWithNoOwnProperty(), 'x', 'y')).to.equal({});
   });
 
+  lab.test('first', () => {
+    expect(Utilities.first([])).to.equal(undefined);
+    expect(Utilities.first({})).to.equal(undefined);
+    expect(Utilities.first(['a', 'b'])).to.equal('a');
+  });
+
   lab.test('sortFirstItem', () => {
     expect(Utilities.sortFirstItem(['a', 'b'])).to.equal(['a', 'b']);
 

--- a/test/unit/utilities-test.js
+++ b/test/unit/utilities-test.js
@@ -190,6 +190,8 @@ lab.experiment('utilities', () => {
   lab.test('toTitleCase', () => {
     expect(Utilities.toTitleCase('test')).to.equal('Test');
     expect(Utilities.toTitleCase('tesT')).to.equal('Test');
+    expect(Utilities.toTitleCase('Test')).to.equal('Test');
+    expect(Utilities.toTitleCase('test Test')).to.equal('Test test');
   });
 
   lab.test('createId', () => {


### PR DESCRIPTION
In this PR I have improved a few things:

- did not use deprecated [String.prototype.substr](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) method;
- simplified a lot of functions, making it more readable;
- used `String.prototype.includes` instead of `String.prototype.indexOf` when possible to speed up the function and make it more readable and do not perform two actions(find the index and check if the index is bigger than -1, like element present into array or string);
- was added more tests and test cases;
- was added one `TODO` to do not miss the important point and add tests later;