### PR TITLE
Fix #748 hostname issues with http2

### DIFF
--- a/examples/http2.js
+++ b/examples/http2.js
@@ -1,0 +1,112 @@
+// `http2.js` - how to use hapi-swagger with http2
+'use strict';
+
+const Fs = require('fs');
+const Path = require('path');
+const Blipp = require('blipp');
+const Hapi = require('@hapi/hapi');
+const Inert = require('@hapi/inert');
+const Vision = require('@hapi/vision');
+const Http2 = require('http2');
+
+const HapiSwagger = require('../');
+const Pack = require('../package');
+const Routes = require('./assets/routes-simple.js');
+
+/**
+ * @type {HapiSwagger.RegisterOptions}
+ */
+const swaggerOptions = {
+  basePath: '/v1',
+  pathPrefixSize: 2,
+  schemes: ['https'],
+  info: {
+    title: 'Test API Documentation',
+    description: 'This is a sample example of API documentation.',
+    version: Pack.version,
+    termsOfService: 'https://github.com/glennjones/hapi-swagger/',
+    contact: {
+      email: 'glennjonesnet@gmail.com'
+    },
+    license: {
+      name: 'MIT',
+      url: 'https://raw.githubusercontent.com/glennjones/hapi-swagger/master/license.txt'
+    }
+  },
+  tags: [
+    {
+      name: 'sum',
+      description: 'working with maths',
+      externalDocs: {
+        description: 'Find out more',
+        url: 'http://example.org'
+      }
+    },
+    {
+      name: 'store',
+      description: 'storing data',
+      externalDocs: {
+        description: 'Find out more',
+        url: 'http://example.org'
+      }
+    },
+    {
+      name: 'properties',
+      description: 'test the use of extended hapi/joi properties',
+      externalDocs: {
+        description: 'Find out more',
+        url: 'http://example.org'
+      }
+    }
+  ]
+};
+
+const ser = async () => {
+  const tls = {
+    key: Fs.readFileSync(Path.join(__dirname, '../test/certs/server.key')),
+    cert: Fs.readFileSync(Path.join(__dirname, '../test/certs/server.crt'))
+  };
+  const server = Hapi.Server({
+    // host: 'localhost',
+    port: 443,
+    // port: 3000,
+    listener: Http2.createSecureServer({ ...tls }),
+    routes: {
+      cors: {
+        origin: ['*']
+      }
+    },
+    tls
+  });
+
+  // Blipp and Good - Needs updating for Hapi v17.x
+  await server.register([
+    Inert,
+    Vision,
+    Blipp,
+    {
+      plugin: HapiSwagger,
+      options: swaggerOptions
+    }
+  ]);
+
+  server.route(Routes);
+
+  server.views({
+    path: 'examples/assets',
+    engines: { html: require('handlebars') },
+    isCached: false
+  });
+
+  await server.start();
+  return server;
+};
+
+ser()
+  .then((server) => {
+    console.log(`Server listening on ${server.info.uri}`);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -14,6 +14,10 @@ const builder = (module.exports = {});
 const internals = {};
 
 /**
+ * @typedef {import('@hapi/hapi').Request}
+ */
+
+/**
  * default data for swagger root object
  */
 builder.default = {
@@ -63,7 +67,7 @@ builder.schema = Joi.object({
  * gets the Swagger JSON
  *
  * @param  {Object} settings
- * @param  {Object} request
+ * @param  {Request} request
  */
 builder.getSwaggerJSON = async (settings, request) => {
   // remove items that cannot be changed by user
@@ -157,7 +161,7 @@ internals.getProxyHeader = function(request, name) {
 /**
  * finds the current host
  *
- * @param  {Object} request
+ * @param  {Request} request
  * @return {string}
  */
 internals.getHost = function(request) {
@@ -166,26 +170,18 @@ internals.getHost = function(request) {
     return proxyHost;
   }
 
-  const reqHost = request.info.host.split(':');
-  const host = reqHost[0];
-  const port = parseInt(reqHost[1] || '', 10);
-  const protocol = request.server.info.protocol;
-
-  // do not set port if its protocol http/https with default post numbers
-  // this cannot be tested on most desktops as ports below 1024 throw EACCES
-  /* $lab:coverage:off$ */
-  if (!isNaN(port) && ((protocol === 'http' && port !== 80) || (protocol === 'https' && port !== 443))) {
-    return host + ':' + port;
+  try {
+    const url = new URL(request.info.referrer);
+    return url.host;
+  } catch (error) {
+    return request.info.host;
   }
-  /* $lab:coverage:on$ */
-
-  return host;
 };
 
 /**
  * finds the current schema
  *
- * @param  {Object} request
+ * @param  {Request} request
  * @return {string}
  */
 internals.getSchema = function(request) {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -174,6 +174,7 @@ internals.getHost = function(request) {
     const url = new URL(request.info.referrer);
     return url.host;
   } catch (error) {
+    // backup in case referrer isn't set for some reason. (i.e. tests)
     return request.info.host;
   }
 };

--- a/test/Integration/http2-test.js
+++ b/test/Integration/http2-test.js
@@ -1,0 +1,51 @@
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+const Helper = require('../helper.js');
+const Validate = require('../../lib/validate.js');
+const Http2 = require('http2');
+const Fs = require('fs/promises');
+const Path = require('path');
+
+const expect = Code.expect;
+const lab = (exports.lab = Lab.script());
+
+lab.experiment('http2', () => {
+  const requestOptions = {
+    method: 'GET',
+    url: '/swagger.json',
+    headers: {
+      referrer: 'https://localhost:12345'
+    }
+  };
+
+  const routes = {
+    method: 'GET',
+    path: '/test',
+    handler: Helper.defaultHandler,
+    options: {
+      tags: ['api']
+    }
+  };
+
+  lab.test('gets correct host', async () => {
+    const [key, cert] = await Promise.all([
+      await Fs.readFile(Path.join(__dirname, '../certs/server.key')),
+      await Fs.readFile(Path.join(__dirname, '../certs/server.crt'))
+    ]);
+    const tls = {
+      key,
+      cert
+    };
+    const url = new URL(requestOptions.headers.referrer);
+    const options = {
+      tls,
+      listener: Http2.createSecureServer({ ...tls, allowHTTP1: true }),
+      port: url.port
+    };
+    const server = await Helper.createServer({}, routes, options);
+    const response = await server.inject({ ...requestOptions });
+    expect(response.result.host).to.equal(new URL(requestOptions.headers.referrer).host);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+});

--- a/test/Integration/http2-test.js
+++ b/test/Integration/http2-test.js
@@ -39,7 +39,7 @@ lab.experiment('http2', () => {
     const url = new URL(requestOptions.headers.referrer);
     const options = {
       tls,
-      listener: Http2.createSecureServer({ ...tls, allowHTTP1: true }),
+      listener: Http2.createSecureServer({ ...tls }),
       port: url.port
     };
     const server = await Helper.createServer({}, routes, options);

--- a/test/Integration/http2-test.js
+++ b/test/Integration/http2-test.js
@@ -3,7 +3,7 @@ const Lab = require('@hapi/lab');
 const Helper = require('../helper.js');
 const Validate = require('../../lib/validate.js');
 const Http2 = require('http2');
-const Fs = require('fs/promises');
+const Fs = require('fs').promises;
 const Path = require('path');
 
 const expect = Code.expect;


### PR DESCRIPTION
Fixes #748 by using `request.info.referrer` if available as the default host for swagger.