### PR TITLE
fix: Remove deprecated and legacy components

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -331,8 +331,10 @@ const appendDataContext = function (plugin, settings) {
 
       // append tags from document request to JSON request
       settings.jsonPath = request.query.tags
-        ? appendQueryString(settings.jsonPath, 'tags', request.query.tags)
-        : appendQueryString(settings.jsonPath, null, null)
+        ? Utilities.appendQueryString(settings.jsonPath, 'tags', request.query.tags)
+        : Utilities.appendQueryString(settings.jsonPath, null, null);
+
+      console.log('result', settings.jsonPath);
 
       const prefixedSettings = Hoek.clone(settings);
       if (routePrefix) {
@@ -355,26 +357,6 @@ const appendDataContext = function (plugin, settings) {
 
     return h.continue;
   });
-};
-
-/**
- * appends a querystring to a url path - will overwrite existing values
- *
- * @param  {string} url
- * @param  {string} qsName
- * @param  {string} qsValue
- * @return {string}
- */
-const appendQueryString = function (url, qsName, qsValue) {
-  const urlObj = Url.parse(url);
-  if (qsName && qsValue) {
-    urlObj.query = Querystring.parse(qsName + '=' + qsValue);
-    urlObj.search = '?' + encodeURIComponent(qsName) + '=' + encodeURIComponent(qsValue);
-  } else {
-    urlObj.search = '';
-  }
-
-  return urlObj.format(urlObj);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -330,11 +330,9 @@ const appendDataContext = function (plugin, settings) {
       /* $lab:coverage:on$ */
 
       // append tags from document request to JSON request
-      if (request.query.tags) {
-        settings.jsonPath = appendQueryString(settings.jsonPath, 'tags', request.query.tags);
-      } else {
-        settings.jsonPath = appendQueryString(settings.jsonPath, null, null);
-      }
+      settings.jsonPath = request.query.tags
+        ? appendQueryString(settings.jsonPath, 'tags', request.query.tags)
+        : appendQueryString(settings.jsonPath, null, null)
 
       const prefixedSettings = Hoek.clone(settings);
       if (routePrefix) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -332,7 +332,7 @@ const appendDataContext = function (plugin, settings) {
       // append tags from document request to JSON request
       settings.jsonPath = request.query.tags
         ? Utilities.appendQueryString(settings.jsonPath, 'tags', request.query.tags)
-        : Utilities.appendQueryString(settings.jsonPath, null, null);
+        : Utilities.appendQueryString(settings.jsonPath);
 
       const prefixedSettings = Hoek.clone(settings);
       if (routePrefix) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -334,8 +334,6 @@ const appendDataContext = function (plugin, settings) {
         ? Utilities.appendQueryString(settings.jsonPath, 'tags', request.query.tags)
         : Utilities.appendQueryString(settings.jsonPath, null, null);
 
-      console.log('result', settings.jsonPath);
-
       const prefixedSettings = Hoek.clone(settings);
       if (routePrefix) {
         ['jsonPath', 'swaggerUIPath'].forEach((setting) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,6 @@ const Hoek = require('@hapi/hoek');
 const Joi = require('joi');
 const Path = require('path');
 const { join, sep } = require('path');
-const Querystring = require('querystring');
-const Url = require('url');
 const swaggerUiAssetPath = require('swagger-ui-dist').getAbsoluteFSPath();
 
 const Pack = require('../package.json');

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -478,13 +478,11 @@ utilities.assignVendorExtensions = function(target, source) {
  * @return {string}
  */
 utilities.appendQueryString = function (url, qsName, qsValue) {
-  const urlObj = Url.parse(url);
-  if (qsName && qsValue) {
-    urlObj.query = Querystring.parse(qsName + '=' + qsValue);
-    urlObj.search = '?' + encodeURIComponent(qsName) + '=' + encodeURIComponent(qsValue);
-  } else {
-    urlObj.search = '';
-  }
+   if (!qsName || !qsValue) {
+     return url;
+   }
 
-  return urlObj.format(urlObj);
+  const query = new URLSearchParams({[qsName]: qsValue});
+
+  return `${url}?${query.toString()}`;
 };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -468,7 +468,7 @@ utilities.assignVendorExtensions = function(target, source) {
 };
 
 /**
- * appends a querystring to a url path - will overwrite existing values
+ * appends a querystring to an url
  *
  * @param  {string} url
  * @param  {string} qsName

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,7 +1,5 @@
 const Hoek = require('@hapi/hoek');
 const Joi = require('joi');
-const Url = require('url');
-const Querystring = require('querystring');
 
 const utilities = (module.exports = {});
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,5 +1,7 @@
 const Hoek = require('@hapi/hoek');
 const Joi = require('joi');
+const Url = require('url');
+const Querystring = require('querystring');
 
 const utilities = (module.exports = {});
 
@@ -465,4 +467,24 @@ utilities.assignVendorExtensions = function(target, source) {
   }
 
   return target;
+};
+
+/**
+ * appends a querystring to a url path - will overwrite existing values
+ *
+ * @param  {string} url
+ * @param  {string} qsName
+ * @param  {string} qsValue
+ * @return {string}
+ */
+utilities.appendQueryString = function (url, qsName, qsValue) {
+  const urlObj = Url.parse(url);
+  if (qsName && qsValue) {
+    urlObj.query = Querystring.parse(qsName + '=' + qsValue);
+    urlObj.search = '?' + encodeURIComponent(qsName) + '=' + encodeURIComponent(qsValue);
+  } else {
+    urlObj.search = '';
+  }
+
+  return urlObj.format(urlObj);
 };

--- a/test/unit/utilities-test.js
+++ b/test/unit/utilities-test.js
@@ -249,4 +249,11 @@ lab.experiment('utilities', () => {
     });
     expect(Utilities.assignVendorExtensions({ a: 1, b: 2 }, { 'x-': 1 })).to.equal({ a: 1, b: 2 });
   });
+
+
+  lab.test('appendQueryString', () => {
+    expect(Utilities.appendQueryString('/test.json', 'tags', 'reduced')).to.equal('/test.json?tags=reduced');
+    expect(Utilities.appendQueryString('/test/test', 'tags', 'reduced')).to.equal('/test/test?tags=reduced');
+    expect(Utilities.appendQueryString('/swagger.json')).to.equal('/swagger.json');
+  });
 });


### PR DESCRIPTION
This PR removes the usage of some deprecated modules into Node.js and add missed test. For example `querystring` and part of `url` modules.
There are a few links:
- [querystring](https://nodejs.org/api/querystring.html#query-string)
- [format](https://nodejs.org/api/url.html#urlformaturlobject)
- [parse](https://nodejs.org/api/url.html#urlparseurlstring-parsequerystring-slashesdenotehost)