### PR TITLE
chore: update repo urls to hapi-swagger

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,10 +6,10 @@ Contributions from the community are welcome. Please follow this guide when logg
 
 ## Logging Issues
 
-All issues should be created using the [new issue form](https://github.com/glennjones/hapi-swagger/issues/new).
+All issues should be created using the [new issue form](https://github.com/hapi-swagger/hapi-swagger/issues/new).
 
--   Please check the "[Features from Hapi that cannot be ported to Swagger](https://github.com/glennjones/hapi-swagger/blob/master/usageguide.md#features-from-hapi-that-cannot-be-ported-to-swagger])" section of the usage guide.
--   Try the plugin option `debug = true` to see if any errors or warning are logged. see [Debugging](https://github.com/glennjones/hapi-swagger/blob/master/usageguide.md#debugging)
+-   Please check the "[Features from Hapi that cannot be ported to Swagger](https://github.com/hapi-swagger/hapi-swagger/blob/master/usageguide.md#features-from-hapi-that-cannot-be-ported-to-swagger])" section of the usage guide.
+-   Try the plugin option `debug = true` to see if any errors or warning are logged. see [Debugging](https://github.com/hapi-swagger/hapi-swagger/blob/master/usageguide.md#debugging)
 -   Clearly describe the issue including steps to reproduce it. Also include example code of any `routes` that cause an issue.
 
 ## Fixes and patches
@@ -20,7 +20,7 @@ Code changes are welcome and should follow the guidelines below. If you wish to 
 -   Fix the issue ensuring that your code follows the [style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
 -   Add tests for your new code ensuring that you have 100% code coverage (we can help you reach 100% but will not merge without it).
     -   Run `npm test` to generate a report of test coverage
--   [Pull requests](https://help.github.com/articles/creating-a-pull-request/) should be made to the [master branch](https://github.com/glennjones/hapi-swagger/tree/master).
+-   [Pull requests](https://help.github.com/articles/creating-a-pull-request/) should be made to the [master branch](https://github.com/hapi-swagger/hapi-swagger/tree/master).
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -3,22 +3,22 @@
 This is a [OpenAPI (aka Swagger)](https://openapis.org/) plug-in for [Hapi](https://hapi.dev/) When installed it will self document the API interface
 in a project.
 
-[![Maintainers Wanted](https://img.shields.io/badge/maintainers-wanted-red.svg?style=for-the-badge)](https://github.com/glennjones/hapi-swagger/issues/718)
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/glennjones/hapi-swagger/Node.js%20CI?style=for-the-badge)
+[![Maintainers Wanted](https://img.shields.io/badge/maintainers-wanted-red.svg?style=for-the-badge)](https://github.com/hapi-swagger/hapi-swagger/issues/718)
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/hapi-swagger/hapi-swagger/Node.js%20CI?style=for-the-badge)
 [![npm downloads](https://img.shields.io/npm/dm/hapi-swagger.svg?style=for-the-badge)](https://www.npmjs.com/package/hapi-swagger)
-[![MIT license](http://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge)](https://raw.github.com/glennjones/hapi-swagger/master/license.txt)
+[![MIT license](http://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge)](https://raw.github.com/hapi-swagger/hapi-swagger/master/license.txt)
 
 ## Compatibility
 
 | Version | [Hapi](https://github.com/hapijs/hapi) | [Joi](https://github.com/sideway/joi) | Node   | Release Notes                                                 |
 | ------- | -------------------------------------- | ------------------------------------- | ------ | ------------------------------------------------------------- |
-| `14.x`  | `>=19.0.0 @hapi/hapi`                  | `>=17.0.0 joi`                        | `>=12` | [#680](https://github.com/glennjones/hapi-swagger/issues/680) |
-| `13.x`  | `>=19.0.0 @hapi/hapi`                  | `>=17.0.0 @hapi/joi`                  | `>=12` | [#660](https://github.com/glennjones/hapi-swagger/issues/660) |
-| `12.x`  | `>=19.0.0 @hapi/hapi`                  | `>=17.0.0 @hapi/joi`                  | `>=12` | [#644](https://github.com/glennjones/hapi-swagger/issues/644) |
-| `11.x`  | `>=18.4.0 @hapi/hapi`                  | `>=16.0.0 @hapi/joi`                  | `>=8`  | [#631](https://github.com/glennjones/hapi-swagger/issues/631) |
-| `10.x`  | `>=18.3.1 @hapi/hapi`                  | `>=14.0.0 @hapi/joi`                  | `>=8`  | [#587](https://github.com/glennjones/hapi-swagger/issues/587) |
-| `9.x`   | `>=17 hapi`                            | `<14.0.0`                             | `>=8`  | [#487](https://github.com/glennjones/hapi-swagger/issues/487) |
-| `7.x`   | `<17 hapi`                             | ???                                   | ???    | [#325](https://github.com/glennjones/hapi-swagger/issues/325) |
+| `14.x`  | `>=19.0.0 @hapi/hapi`                  | `>=17.0.0 joi`                        | `>=12` | [#680](https://github.com/hapi-swagger/hapi-swagger/issues/680) |
+| `13.x`  | `>=19.0.0 @hapi/hapi`                  | `>=17.0.0 @hapi/joi`                  | `>=12` | [#660](https://github.com/hapi-swagger/hapi-swagger/issues/660) |
+| `12.x`  | `>=19.0.0 @hapi/hapi`                  | `>=17.0.0 @hapi/joi`                  | `>=12` | [#644](https://github.com/hapi-swagger/hapi-swagger/issues/644) |
+| `11.x`  | `>=18.4.0 @hapi/hapi`                  | `>=16.0.0 @hapi/joi`                  | `>=8`  | [#631](https://github.com/hapi-swagger/hapi-swagger/issues/631) |
+| `10.x`  | `>=18.3.1 @hapi/hapi`                  | `>=14.0.0 @hapi/joi`                  | `>=8`  | [#587](https://github.com/hapi-swagger/hapi-swagger/issues/587) |
+| `9.x`   | `>=17 hapi`                            | `<14.0.0`                             | `>=8`  | [#487](https://github.com/hapi-swagger/hapi-swagger/issues/487) |
+| `7.x`   | `<17 hapi`                             | ???                                   | ???    | [#325](https://github.com/hapi-swagger/hapi-swagger/issues/325) |
 
 ## Installation
 
@@ -28,7 +28,7 @@ You can add the module to your Hapi using npm:
 > npm install hapi-swagger --save
 ```
 
-**hapi-swagger** no longer bundles `joi` to fix [#648](https://github.com/glennjones/hapi-swagger/issues/648). Install **hapi-swagger** with peer dependencies using:
+**hapi-swagger** no longer bundles `joi` to fix [#648](https://github.com/hapi-swagger/hapi-swagger/issues/648). Install **hapi-swagger** with peer dependencies using:
 
 ```bash
 npx install-peerdeps hapi-swagger

--- a/examples/custom.js
+++ b/examples/custom.js
@@ -57,13 +57,13 @@ const swaggerOptions = {
     title: 'Test API Documentation',
     description: 'This is a sample example of API documentation.',
     version: Pack.version,
-    termsOfService: 'https://github.com/glennjones/hapi-swagger/',
+    termsOfService: 'https://github.com/hapi-swagger/hapi-swagger/',
     contact: {
       email: 'glennjonesnet@gmail.com'
     },
     license: {
       name: 'MIT',
-      url: 'https://raw.githubusercontent.com/glennjones/hapi-swagger/master/license.txt'
+      url: 'https://raw.githubusercontent.com/hapi-swagger/hapi-swagger/master/license.txt'
     }
   },
   tags: [

--- a/examples/http2.js
+++ b/examples/http2.js
@@ -24,13 +24,13 @@ const swaggerOptions = {
     title: 'Test API Documentation',
     description: 'This is a sample example of API documentation.',
     version: Pack.version,
-    termsOfService: 'https://github.com/glennjones/hapi-swagger/',
+    termsOfService: 'https://github.com/hapi-swagger/hapi-swagger/',
     contact: {
       email: 'glennjonesnet@gmail.com'
     },
     license: {
       name: 'MIT',
-      url: 'https://raw.githubusercontent.com/glennjones/hapi-swagger/master/license.txt'
+      url: 'https://raw.githubusercontent.com/hapi-swagger/hapi-swagger/master/license.txt'
     }
   },
   tags: [

--- a/examples/options.js
+++ b/examples/options.js
@@ -45,13 +45,13 @@ const swaggerOptions = {
     title: 'Test API Documentation',
     description: 'This is a sample example of API documentation.',
     version: Pack.version,
-    termsOfService: 'https://github.com/glennjones/hapi-swagger/',
+    termsOfService: 'https://github.com/hapi-swagger/hapi-swagger/',
     contact: {
       email: 'glennjonesnet@gmail.com'
     },
     license: {
       name: 'MIT',
-      url: 'https://raw.githubusercontent.com/glennjones/hapi-swagger/master/license.txt'
+      url: 'https://raw.githubusercontent.com/hapi-swagger/hapi-swagger/master/license.txt'
     }
   },
   tags: [

--- a/examples/ssl.js
+++ b/examples/ssl.js
@@ -19,13 +19,13 @@ const swaggerOptions = {
     title: 'Test API Documentation',
     description: 'This is a sample example of API documentation.',
     version: Pack.version,
-    termsOfService: 'https://github.com/glennjones/hapi-swagger/',
+    termsOfService: 'https://github.com/hapi-swagger/hapi-swagger/',
     contact: {
       email: 'glennjonesnet@gmail.com'
     },
     license: {
       name: 'MIT',
-      url: 'https://raw.githubusercontent.com/glennjones/hapi-swagger/master/license.txt'
+      url: 'https://raw.githubusercontent.com/hapi-swagger/hapi-swagger/master/license.txt'
     }
   },
   tags: [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Glenn Jones",
   "repository": {
     "type": "git",
-    "url": "git://github.com/glennjones/hapi-swagger.git"
+    "url": "git://github.com/hapi-swagger/hapi-swagger.git"
   },
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/Integration/alternatives-test.js
+++ b/test/Integration/alternatives-test.js
@@ -127,7 +127,7 @@ lab.experiment('alternatives', () => {
               .label('Type'),
             key: Joi.string().when('category', {
               is: 'stuff',
-              then: Joi.forbidden() // https://github.com/glennjones/hapi-swagger/issues/338
+              then: Joi.forbidden() // https://github.com/hapi-swagger/hapi-swagger/issues/338
             }),
             data: Joi.alternatives()
               .conditional('type', { is: 'string', then: Joi.string() })

--- a/test/Integration/grouping-test.js
+++ b/test/Integration/grouping-test.js
@@ -30,13 +30,13 @@ const swaggerOptions = {
     title: 'Test API Documentation',
     description: 'This is a sample example of API documentation.',
     version: '1.0.0',
-    termsOfService: 'https://github.com/glennjones/hapi-swagger/',
+    termsOfService: 'https://github.com/hapi-swagger/hapi-swagger/',
     contact: {
       email: 'glennjonesnet@gmail.com'
     },
     license: {
       name: 'MIT',
-      url: 'https://raw.githubusercontent.com/glennjones/hapi-swagger/master/license.txt'
+      url: 'https://raw.githubusercontent.com/hapi-swagger/hapi-swagger/master/license.txt'
     }
   }
 };

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -250,7 +250,7 @@ lab.experiment('property - ', () => {
       type: 'string',
       pattern: '^[a-zA-Z0-9]{3,30}'
     });
-    // covers https://github.com/glennjones/hapi-swagger/issues/652 -
+    // covers https://github.com/hapi-swagger/hapi-swagger/issues/652 -
     // make sure we aren't truncating the regex after an internal '/',
     // and make sure we omit any regex flags (g, i, m) from the
     // resulting pattern


### PR DESCRIPTION
Small change to update all the urls so they point to the new https://github.com/hapi-swagger/hapi-swagger/ repo rather the the old one under may name