### PR TITLE
feat: enable null values in examples

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -81,12 +81,16 @@ utilities.deleteEmptyProperties = function(obj) {
   for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       // delete properties undefined values
-      if (obj[key] === undefined || obj[key] === null) {
+      if (obj[key] === undefined) {
         delete obj[key];
       }
 
       // allow blank objects for example or default properties
-      if (['default', 'example', 'security'].indexOf(key) === -1) {
+      if (!['default', 'example', 'security'].includes(key)) {
+        if (obj[key] === null) {
+          delete obj[key];
+        }
+
         // delete array with no values
         if (Array.isArray(obj[key]) && obj[key].length === 0) {
           delete obj[key];


### PR DESCRIPTION
This PR aims to allow null as a valid value for examples, default values and security.
This can be useful for APIs that accept patches with null values for instance.

Minimal test app : https://github.com/AppeninTerenceBARBE/test-hapi-swagger
Test with the branch `feat/use-null-fork`

**Example before:**
![image](https://user-images.githubusercontent.com/117666990/200375875-f14863a3-7913-46bb-8007-95fb2b9ba388.png)

**Example after:**
![image](https://user-images.githubusercontent.com/117666990/200374034-b7d894af-ac70-43fb-81d3-c83d963947cc.png)