### PR TITLE
Fix/always set required and optional on parent

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,13 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "attach",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node"
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "start",
@@ -68,7 +75,7 @@
       "skipFiles": ["<node_internals>/**/*.js"],
       "console": "integratedTerminal",
       "disableOptimisticBPs": true
-    },
+    }
   ],
   "inputs": [
     {

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -102,6 +102,9 @@ internals.properties.prototype.parseProperty = function (name, joiObj, parent, p
     property.format = map.format;
   }
 
+  // this must be done even if the caching returns something
+  this.setRequiredAndOptionalOnParent(name, parent, joiObj);
+
   // Joi object caching - speeds up parsing
   let joiCache;
   if (useDefinitions && Array.isArray(this.definitionCache) && property.type === 'object') {
@@ -231,6 +234,58 @@ internals.properties.prototype.parseProperty = function (name, joiObj, parent, p
 };
 
 /**
+ * set required and optional properties on parent if they do not exist yet
+ *
+ * @param  {string} name
+ * @param  {string} parent
+ * @param  {Object} joiObj
+ * @returns {void}
+ */
+internals.properties.prototype.setRequiredAndOptionalOnParent = function (name, parent, joiObj) {
+  // nothing needs to be done if the parent or the property doesn't exist
+  if (!parent || !name) {
+    return;
+  }
+
+  const describe = joiObj.describe();
+
+  if (Hoek.reach(joiObj, '_flags.presence')) {
+    if (parent.required === undefined) {
+      parent.required = [];
+    }
+
+    if (parent.optional === undefined) {
+      parent.optional = [];
+    }
+
+    if (Hoek.reach(joiObj, '_flags.presence') === 'required') {
+      if (!parent.required.includes(name)) {
+        parent.required.push(name);
+      }
+    }
+
+    if (Hoek.reach(joiObj, '_flags.presence') === 'optional') {
+      if (!parent.optional.includes(name)) {
+        parent.optional.push(name);
+      }
+    }
+  }
+
+  // interdependencies are not yet supported https://github.com/OAI/OpenAPI-Specification/issues/256
+  if (describe.whens && describe.whens.length > 0) {
+    describe.whens.forEach((test) => {
+      if (Hoek.reach(test, 'then.flags.presence') === 'required') {
+        if (parent.required === undefined) {
+          parent.required = [];
+        }
+
+        parent.required.push(name);
+      }
+    });
+  }
+};
+
+/**
  * parse property metadata
  *
  * @param  {Object} property
@@ -270,39 +325,7 @@ internals.properties.prototype.parsePropertyMetadata = function (property, name,
     }
   }
 
-  // add required/optional state only if present
-  if (parent && name) {
-    if (Hoek.reach(joiObj, '_flags.presence')) {
-      if (parent.required === undefined) {
-        parent.required = [];
-      }
-
-      if (parent.optional === undefined) {
-        parent.optional = [];
-      }
-
-      if (Hoek.reach(joiObj, '_flags.presence') === 'required') {
-        parent.required.push(name);
-      }
-
-      if (Hoek.reach(joiObj, '_flags.presence') === 'optional') {
-        parent.optional.push(name);
-      }
-    }
-
-    // interdependencies are not yet supported https://github.com/OAI/OpenAPI-Specification/issues/256
-    if (describe.whens && describe.whens.length > 0) {
-      describe.whens.forEach((test) => {
-        if (Hoek.reach(test, 'then.flags.presence') === 'required') {
-          if (parent.required === undefined) {
-            parent.required = [];
-          }
-
-          parent.required.push(name);
-        }
-      });
-    }
-  }
+  this.setRequiredAndOptionalOnParent(name, parent, joiObj);
 
   property.default = Hoek.reach(joiObj, '_flags.default');
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "start:routes:simple": "node examples/group-ordered.js",
     "test": "yarn test:lib",
     "test:lib": "lab -L -t 97 -I '__core-js_shared__,regeneratorRuntime,core,CSS,Symbol(undici.globalDispatcher.1)'",
+    "test:lib:debug": "lab --inspect-brk -S -I '__core-js_shared__,regeneratorRuntime,core,CSS,Symbol(undici.globalDispatcher.1)'",
     "test:ts": "tsd",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/test/Integration/parent-required-optional.js
+++ b/test/Integration/parent-required-optional.js
@@ -1,0 +1,51 @@
+const Code = require('@hapi/code');
+const Joi = require('joi');
+const Lab = require('@hapi/lab');
+const Helper = require('../helper.js');
+const Validate = require('../../lib/validate.js');
+
+const expect = Code.expect;
+const lab = (exports.lab = Lab.script());
+
+lab.experiment('path', () => {
+  const requiredChildSchema = Joi.object({
+    p1: Joi.string()
+  }).required();
+
+  const responseBodySchema = Joi.object({
+    requiredChild: requiredChildSchema
+  }).label('Response');
+
+  const requestBodySchema = Joi.object({
+    requiredChild: requiredChildSchema,
+    optionalChild: requiredChildSchema.optional()
+  }).label('Request');
+
+  const routes = {
+    method: 'POST',
+    path: '/test',
+    handler: Helper.defaultHandler,
+    options: {
+      description: 'Required should appear on response and request',
+      notes: ['Testing'],
+      tags: ['api'],
+      validate: {
+        payload: requestBodySchema
+      },
+      response: {
+        schema: responseBodySchema
+      }
+    }
+  };
+
+  lab.test('parent required should include required children', async () => {
+    // we need to set reuseDefinitions to false here otherwise,
+    // Request would be reused for Response as they're too similar
+    const server = await Helper.createServer({ reuseDefinitions: false }, routes);
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+    expect(response.result.definitions.Request.required).to.equal(['requiredChild']);
+    expect(response.result.definitions.Response.required).to.equal(['requiredChild']);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+});


### PR DESCRIPTION
Fixes issue #357 

This PR aims to ensure required fields are set on parents even when reused.
I've added one test, but since I'm not too familiar with the library, feel free to comment or give me directions if need be.

Test repo: https://github.com/appenin/hapi-swagger-test / use branch `test/set-required-on-parent`.

Before:
![image](https://user-images.githubusercontent.com/117666990/203365997-2621ada2-98ba-4e8a-876f-6f110459fe03.png)

After:
![image](https://user-images.githubusercontent.com/117666990/203364806-0d073b4b-d563-40c3-90d1-e59c3603e2b4.png)
