### PR TITLE
fix: crash if grouping is set to `tags` but route is missing `options.tag`

### DIFF
--- a/lib/paths.js
+++ b/lib/paths.js
@@ -190,7 +190,7 @@ internals.paths.prototype.buildRoutes = function(routes) {
 
     // tags in swagger are used for grouping
     if (this.settings.grouping === 'tags') {
-      out.tags = route.tags.filter(this.settings.tagsGroupingFilter);
+      out.tags = (route.tags || []).filter(this.settings.tagsGroupingFilter);
     } else {
       out.tags = route.groups;
     }


### PR DESCRIPTION
Add check if route.tags is undefined and use an empty array for filtering