### PR TITLE
Fix issue 366

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -345,7 +345,10 @@ declare namespace hapiswagger {
     xProperties?: boolean;
 
     /**
-     * Reuse of definition models to save space
+     * Reuse of definition models to save space.
+     * Even if two routes have the same definition, but labels are not set, the plugin assumes that it is a different
+     * definition, the same if one definition has a label and another does not.
+     * To really reuse the definition model you need to keep the definition and labels the same.
      * @default: true
      */
     reuseDefinitions?: boolean;

--- a/lib/definitions.js
+++ b/lib/definitions.js
@@ -70,7 +70,7 @@ internals.append = function(definitionName, definition, currentCollection, force
 
   // find definitionName by matching hash of object
   if (settings.reuseDefinitions) {
-    foundDefinitionName = internals.hasDefinition(definition, currentCollection);
+    foundDefinitionName = internals.hasDefinition(definitionName, definition, currentCollection);
   }
 
   if (foundDefinitionName) {
@@ -140,16 +140,17 @@ internals.nextModelName = function(nextModelNamePrefix, currentCollection) {
 /**
  * returns whether a collection already has a definition, returns key if found
  *
+ * @param  {string} definitionName
  * @param  {Object} definition
  * @param  {Object} currentCollection
- * @return {String || null}
+ * @return {string || null}
  */
-internals.hasDefinition = function(definition, currentCollection) {
+internals.hasDefinition = function(definitionName, definition, currentCollection) {
   const definitionSet = new Set([JSON.stringify(definition)]);
 
   for (const key in currentCollection) {
     if (definitionSet.has(JSON.stringify(currentCollection[key]))) {
-      return key;
+      return key === definitionName ? key : null;
     }
   }
 

--- a/optionsreference.md
+++ b/optionsreference.md
@@ -42,7 +42,7 @@
 -   `consumes`: (array) The mime types consumed - default: `['application/json']`
 -   `produces`: (array) The mime types produced - default: `['application/json']`
 -   `xProperties`: Adds JOI data that cannot be use directly by swagger as metadata - default: `true`
--   `reuseDefinitions`: Reuse of definition models to save space - default: `true`
+-   `reuseDefinitions`: Reuse of definition models to save space. To really reuse the definition model you need to keep the definition and labels the same. - default: `true`
 -   `definitionPrefix`: Dynamic naming convention. `default` or `useLabel` - default: `default`
 -   `deReference`: Dereferences JSON output - default: `false`,
 -   `debug`: Validates the JSON output against swagger specification - default: `false`

--- a/test/Integration/alternatives-test.js
+++ b/test/Integration/alternatives-test.js
@@ -294,15 +294,25 @@ lab.experiment('alternatives', () => {
 
     expect(response.result.definitions).to.equal({
       Alternative: {
+        type: 'object',
         properties: {
           name: {
             type: 'string'
           }
         },
-        required: ['name'],
-        type: 'object'
+        required: ['name']
+      },
+      Alt: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string'
+          }
+        },
+        required: ['name']
       },
       Dimensions: {
+        type: 'object',
         properties: {
           width: {
             type: 'number'
@@ -310,14 +320,14 @@ lab.experiment('alternatives', () => {
           height: {
             type: 'number'
           }
-        },
-        type: 'object'
+        }
       },
       Type: {
         enum: ['string', 'number', 'image'],
         type: 'string'
       },
-      'Model1': {
+      Model1: {
+        type: 'object',
         properties: {
           type: {
             $ref: '#/definitions/Type'
@@ -326,27 +336,37 @@ lab.experiment('alternatives', () => {
             type: 'string'
           },
           extra: {
-            $ref: '#/definitions/Dimensions'
+            '$ref': '#/definitions/Dimensions'
           }
-        },
-        type: 'object'
+        }
       },
-      'Model2': {
+      Extra: {
+        type: 'object',
         properties: {
-          data: {
-            type: 'string'
+          width: {
+            type: 'number'
           },
-          extra: {
-            $ref: '#/definitions/Dimensions'
+          height: {
+            type: 'number'
+          }
+        }
+      },
+      Model2: {
+        type: 'object',
+        properties: {
+          type: {
+            $ref: '#/definitions/Type'
           },
           key: {
             type: 'string'
           },
-          type: {
-            $ref: '#/definitions/Type'
+          data: {
+            type: 'string'
+          },
+          extra: {
+            $ref: '#/definitions/Extra'
           }
-        },
-        type: 'object'
+        }
       }
     });
 

--- a/test/Integration/builder-test.js
+++ b/test/Integration/builder-test.js
@@ -186,12 +186,20 @@ lab.experiment('builder', () => {
     expect(isValid).to.be.true();
   });
 
-  lab.test('reuseDefinitions : true', async () => {
+  lab.test('reuseDefinitions : true. It should not be reused, because of the exact definition, but a different label.', async () => {
     const server = await Helper.createServer({ reuseDefinitions: true }, reuseModelsRoutes);
     const response = await server.inject({ method: 'GET', url: '/swagger.json' });
 
     expect(response.result.definitions).to.equal({
       a: {
+        type: 'object',
+        properties: {
+          a: {
+            type: 'string'
+          }
+        }
+      },
+      b: {
         type: 'object',
         properties: {
           a: {
@@ -206,7 +214,7 @@ lab.experiment('builder', () => {
             $ref: '#/definitions/a'
           },
           b: {
-            $ref: '#/definitions/a'
+            $ref: '#/definitions/b'
           }
         }
       }

--- a/test/Integration/definitions-test.js
+++ b/test/Integration/definitions-test.js
@@ -102,9 +102,9 @@ lab.experiment('definitions', () => {
 
     expect(response.statusCode).to.equal(200);
     expect(response.result.paths['/test/'].post.parameters[0].schema).to.equal({
-      $ref: '#/definitions/Model1'
+      $ref: '#/definitions/Model2'
     });
-    expect(response.result.definitions.Model1).to.equal(definition);
+    expect(response.result.definitions.Model2).to.equal(definition);
     const isValid = await Validate.test(response.result);
     expect(isValid).to.be.true();
   });
@@ -318,5 +318,102 @@ lab.experiment('definitions', () => {
       },
       required: ['id', 'reminder']
     });
+  });
+
+  lab.test('test that similar object definition with different labels are not merged', async () => {
+
+    const testRoutes = [
+      {
+        method: 'POST',
+        path: '/users',
+        options: {
+          handler: Helper.defaultHandler,
+          description: 'Create new end-user',
+          notes: 'Create user',
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              name: Joi.string().required(),
+              email: Joi.string().email().required()
+            }).label('user')
+          }
+        },
+      },
+      {
+        method: 'POST',
+        path: '/admins',
+        options: {
+          handler: Helper.defaultHandler,
+          description: 'Create new admin',
+          notes: 'Create admin',
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              name: Joi.string().required(),
+              email: Joi.string().email().required()
+            }).label('admin')
+          }
+        },
+      },
+      {
+        method: 'PUT',
+        path: '/admins',
+        options: {
+          handler: Helper.defaultHandler,
+          description: 'Update admin',
+          notes: 'Update admin',
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              name: Joi.string().required(),
+              email: Joi.string().email().required()
+            }).label('admin')
+          }
+        }
+      },
+      {
+        method: 'PUT',
+        path: '/other',
+        options: {
+          handler: Helper.defaultHandler,
+          description: 'Other',
+          notes: 'Other',
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              name: Joi.string().required(),
+              email: Joi.string().email().required()
+            }).label('other')
+          }
+        }
+      },
+      {
+        method: 'PUT',
+        path: '/unknown',
+        options: {
+          handler: Helper.defaultHandler,
+          description: 'Unknown',
+          notes: 'Unknown',
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              name: Joi.string().required(),
+              email: Joi.string().email().required()
+            })
+          }
+        },
+      }
+    ];
+
+    const server = await Helper.createServer({}, testRoutes);
+
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+
+    expect(response.statusCode).to.equal(200);
+    expect(Object.keys(response.result.definitions).length).to.equal(4);
+    expect(Object.keys(response.result.definitions).includes('admin')).to.equal(true);
+    expect(Object.keys(response.result.definitions).includes('user')).to.equal(true);
+    expect(Object.keys(response.result.definitions).includes('other')).to.equal(true);
+    expect(Object.keys(response.result.definitions).includes('Model1')).to.equal(true);
   });
 });

--- a/test/Integration/responses-tests.js
+++ b/test/Integration/responses-tests.js
@@ -847,22 +847,22 @@ lab.experiment('responses', () => {
               }
             },
             400: {
-              schema: {
-                $ref: '#/definitions/Model1'
-              },
-              description: '400 - Added from plugin-options'
-            },
-            404: {
-              description: '404 from response status object',
+              description: '400 - Added from plugin-options',
               schema: {
                 $ref: '#/definitions/Model1'
               }
             },
-            429: {
+            404: {
+              description: '404 from response status object',
               schema: {
-                $ref: '#/definitions/Model1'
-              },
-              description: 'Too Many Requests'
+                $ref: '#/definitions/Model4'
+              }
+            },
+            429: {
+              description: 'Too Many Requests',
+              schema: {
+                $ref: '#/definitions/Model3'
+              }
             },
             500: {
               description: '500 - Added from plugin-options'

--- a/usageguide.md
+++ b/usageguide.md
@@ -127,9 +127,9 @@ validate: {
 ```
 
 **NOTE: the plugin reuses "definition models" these describe each JSON object use by an API i.e. a "user". This feature
-was added to reduce the size of the JSON. The reuse of models can cause names to be reused as well. Please switch
-`options.reuseDefinitions` to `false` if you are naming your JOI objects. By default objects are named in a "Model #"
-format. To use the `label`, specify `options.definitionPrefix` as `useLabel`.**
+was added to reduce the size of the JSON. The plugin can reuse the model only if the labels match. Even if two routes have the same definition, but labels are not set, the plugin assumes that it is a different definition, the same if one definition has a label and another does not. 
+
+By default, objects are named in a "Model #" format. To use the `label`, specify `options.definitionPrefix` as `useLabel`.**
 
 ## Grouping endpoints by path or tags
 


### PR DESCRIPTION
This is my reworked PR. @robmcguinness please check once you have time for it.

This PR changes the behavior for the `reuseDefinitions` option(make it more strict). Also, this fixes the [issue](https://github.com/hapi-swagger/hapi-swagger/issues/366).
These changes apply to how the plugin reuses definitions. For now to really reuse the definition model you need to keep the definition and labels the same.