### PR TITLE
Fix issue #786

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -486,17 +486,20 @@ utilities.assignVendorExtensions = function(target, source) {
 /**
  * appends a querystring to an url
  *
- * @param  {string} url
+ * @param  {string} inputUrl
  * @param  {string} qsName
  * @param  {string} qsValue
  * @return {string}
  */
-utilities.appendQueryString = function (url, qsName, qsValue) {
-   if (!qsName || !qsValue) {
-     return url;
-   }
+utilities.appendQueryString = function (inputUrl, qsName, qsValue) {
+  if (!qsName || !qsValue) {
+    return inputUrl;
+  }
 
-  const query = new URLSearchParams({[qsName]: qsValue});
+  const [ url, queryString ] = inputUrl.split('?');
+  const searchParams = new URLSearchParams(queryString);
 
-  return `${url}?${query.toString()}`;
+  searchParams.set(qsName, qsValue);
+
+  return `${url}?${searchParams.toString()}`;
 };

--- a/test/unit/utilities-test.js
+++ b/test/unit/utilities-test.js
@@ -313,6 +313,8 @@ lab.experiment('utilities', () => {
   lab.test('appendQueryString', () => {
     expect(Utilities.appendQueryString('/test.json', 'tags', 'reduced')).to.equal('/test.json?tags=reduced');
     expect(Utilities.appendQueryString('/test/test', 'tags', 'reduced')).to.equal('/test/test?tags=reduced');
+    expect(Utilities.appendQueryString('/test/test?tags=reduced', 'tags', 'reduced')).to.equal('/test/test?tags=reduced');
+    expect(Utilities.appendQueryString('/test/test?tags=reduced', 'tags', 'api')).to.equal('/test/test?tags=api');
     expect(Utilities.appendQueryString('/swagger.json')).to.equal('/swagger.json');
     expect(Utilities.appendQueryString('/swagger.json', 'query')).to.equal('/swagger.json');
     expect(Utilities.appendQueryString('/swagger.json', '', 'query')).to.equal('/swagger.json');


### PR DESCRIPTION
This PR is addressed to update the function `Utilities.appendQueryString` behavior. As noted in this [issue](https://github.com/hapi-swagger/hapi-swagger/issues/786), this function does not cover duplication query keys after my last changes.

Until my previous changes, this function completely overrides all query string and append a new one. I am not sure that it was correct behavior because the function is called `appendQueryString` not `overrideQueryString` or `setQueryString`. My new implementation takes it into account more precisely. So, this function does not override the current query string, instead of function adds a new query to it if missed or updates the existing one.