### PR TITLE
feat: OpenAPI v3.0 support

### DIFF
--- a/examples/simple-openapi.js
+++ b/examples/simple-openapi.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const Hapi = require('@hapi/hapi');
+const Joi = require('joi');
+const Blipp = require('blipp');
+const Inert = require('@hapi/inert');
+const Vision = require('@hapi/vision');
+
+const HapiSwagger = require('../');
+
+const swaggerOptions = {
+  info: {
+    title: 'Test API Documentation',
+    description: 'This is a sample example of API documentation.'
+  },
+  OAS: 'v3.0'
+};
+
+const ser = async () => {
+  const server = Hapi.Server({
+    host: 'localhost',
+    port: 3000
+  });
+
+  await server.register([
+    Inert,
+    Vision,
+    Blipp,
+    {
+      plugin: HapiSwagger,
+      options: swaggerOptions
+    }
+  ]);
+
+  server.route({
+    method: 'PUT',
+    path: '/v1/store/{id?}',
+    options: {
+      handler: (request, h) => {
+        return h.response('success');
+      },
+      description: 'Update sum',
+      notes: ['Update a sum in our data store'],
+      plugins: {
+        'hapi-swagger': {
+          payloadType: 'form'
+        }
+      },
+      tags: ['api'],
+      validate: {
+        params: Joi.object({
+          id: Joi.string().required().description('the id of the sum in the store')
+        }),
+        payload: Joi.object({
+          a: Joi.number().required().description('the first number').default('1'),
+
+          b: Joi.number().required().description('the second number').example('2'),
+
+          operator: Joi.string()
+            .required()
+            .default('+')
+            .valid('+', '-', '/', '*')
+            .description('the operator i.e. + - / or *'),
+
+          equals: Joi.number().required().description('the result of the sum')
+        })
+      }
+    }
+  });
+
+  await server.start();
+  return server;
+};
+
+ser()
+  .then((server) => {
+    console.log(`Server listening on ${server.info.uri}`);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,13 +57,13 @@ declare namespace hapiswagger {
 
   type UiCompleteScriptObjectType = {
     src: string;
-  }
+  };
 
-  type UiCompleteScriptType = string | UiCompleteScriptObjectType
+  type UiCompleteScriptType = string | UiCompleteScriptObjectType;
 
   type ScopesType = {
     [scope: string]: string | any;
-  }
+  };
 
   type SecuritySchemeType = {
     /**
@@ -110,7 +110,7 @@ declare namespace hapiswagger {
      * Any property or object with a key starting with `x-*` is included in the Swagger definition (similar to `x-*` options in the `info` object)
      */
     [key: string]: any;
-  }
+  };
 
   /**
    * Lists the required security schemes to execute this operation. The object can have multiple security schemes declared in it which are all required (that is, there is a logical AND between the schemes)
@@ -217,14 +217,23 @@ declare namespace hapiswagger {
 
   interface RegisterOptions {
     /**
-     * The transfer protocol of the API ie `['http']`
+     * The transfer protocol of the API ie `['http']` (used only with OAS v2)
      */
     schemes?: string[];
 
     /**
-     * The host (name or IP) serving the API including port if any i.e. `localhost:8080`
+     * The host (name or IP) serving the API including port if any i.e. `localhost:8080` (used only with OAS v2)
      */
     host?: string;
+
+    /**
+     * An array of OpenAPI 3.0 server objects (used only with OAS v3)
+     */
+    servers?: {
+      url: string;
+      description?: string;
+      variables?: Record<string, { enum?: string[]; default: string; description: string }>;
+    }[];
 
     /**
      * Defines security strategy to use for plugin resources
@@ -280,7 +289,7 @@ declare namespace hapiswagger {
      * (tags) => !tags.includes('private')
      * ```
      */
-    routeTag?: string | ((tags: string[]) => boolean)
+    routeTag?: string | ((tags: string[]) => boolean);
 
     /**
      * How to create grouping of endpoints value either `path` or `tags`
@@ -358,6 +367,12 @@ declare namespace hapiswagger {
      * @default: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
      */
     wildcardMethods?: string[];
+
+    /**
+     * The swagger version to use.
+     * @default: 'v2'
+     */
+    OAS?: 'v2' | 'v3.0';
 
     /**
      * Dynamic naming convention. `default` or `useLabel`

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -21,28 +21,16 @@ const internals = {};
  * default data for swagger root object
  */
 builder.default = {
-  swagger: '2.0',
-  host: 'localhost',
   basePath: '/',
   routeTag: 'api'
 };
 
-/**
- * schema for swagger root object
- */
-builder.schema = Joi.object({
-  swagger: Joi.string().valid('2.0').required(),
+internals.openapiBaseSchema = Joi.object({
   info: Joi.any(),
-  host: Joi.string(), // JOI hostname validator too strict
-  basePath: Joi.string().regex(/^\//),
   schemes: Joi.array().items(Joi.string().valid('http', 'https', 'ws', 'wss')).optional(),
   consumes: Joi.array().items(Joi.string()),
   produces: Joi.array().items(Joi.string()),
   paths: Joi.any(),
-  definitions: Joi.any(),
-  parameters: Joi.any(),
-  responses: Joi.any(),
-  securityDefinitions: Joi.any(),
   security: Joi.any(),
   grouping: Joi.string().valid('path', 'tags'),
   tagsGroupingFilter: Joi.func(),
@@ -57,7 +45,39 @@ builder.schema = Joi.object({
     expiresAt: Joi.string(),
     generateTimeout: Joi.number()
   })
-}).pattern(/^x-/, Joi.any());
+})
+  .or('swagger', 'openapi')
+  .pattern(/^x-/, Joi.any());
+
+/**
+ * schema for swagger root object
+ */
+builder.schema = {
+  swagger: internals.openapiBaseSchema.keys({
+    swagger: Joi.string().valid('2.0').required(),
+    host: Joi.string(), // JOI hostname validator too strict
+    basePath: Joi.string().regex(/^\//),
+    definitions: Joi.any(),
+    parameters: Joi.any(),
+    responses: Joi.any(),
+    securityDefinitions: Joi.any()
+  }),
+  openapi3: internals.openapiBaseSchema.keys({
+    openapi: Joi.string().valid('3.0.0').required(),
+    servers: Joi.array().items(
+      Joi.object({
+        url: Joi.string().uri(),
+        description: Joi.string()
+      })
+    ),
+    components: Joi.object({
+      schemas: Joi.any(),
+      parameters: Joi.any(),
+      responses: Joi.any(),
+      securitySchemes: Joi.any()
+    })
+  })
+};
 
 /**
  * gets the Swagger JSON
@@ -71,16 +91,27 @@ builder.getSwaggerJSON = async (settings, request) => {
   delete settings.templates;
 
   // collect root information
-  builder.default.host = internals.getHost(request);
-  builder.default.schemes = [internals.getSchema(request)];
 
   settings = Hoek.applyToDefaults(builder.default, settings);
   if (settings.basePath !== '/') {
     settings.basePath = Utilities.removeTrailingSlash(settings.basePath);
   }
 
-  let out = internals.removeNoneSchemaOptions(settings);
-  Joi.assert(out, builder.schema);
+  if (settings.OAS === 'v2') {
+    settings.swagger = '2.0';
+    settings.host = settings.host || internals.getHost(request);
+    settings.schemes = settings.schemes || [internals.getSchema(request)];
+  } else {
+    settings.openapi = '3.0.0';
+    settings.servers = settings.servers || [{ url: internals.getServerUrl(request, settings) }];
+    settings.components = {};
+    if (settings.securityDefinitions) {
+      settings.components.securitySchemes = settings.securityDefinitions;
+    }
+  }
+
+  let out = internals.removeNoneSchemaOptions(settings, settings);
+  Joi.assert(out, settings.OAS === 'v2' ? builder.schema.swagger : builder.schema.openapi3);
 
   if (settings.customSwaggerFile) {
     Object.assign(settings.customSwaggerFile, out);
@@ -113,12 +144,23 @@ builder.getSwaggerJSON = async (settings, request) => {
   const paths = new Paths(settings);
   const pathData = paths.build(routes);
   out.paths = pathData.paths;
-  out.definitions = pathData.definitions;
+
+  if (settings.OAS === 'v2') {
+    out.definitions = pathData.definitions;
+  } else {
+    out.components.schemas = pathData.definitions;
+  }
+
   if (Utilities.hasProperties(pathData['x-alt-definitions'])) {
     out['x-alt-definitions'] = pathData['x-alt-definitions'];
   }
 
-  out = internals.removeNoneSchemaOptions(out);
+  out = internals.removeNoneSchemaOptions(out, settings);
+
+  if (settings.OAS === 'v3.0') {
+    delete out.produces;
+    delete out.consumes;
+  }
 
   if (settings.debug) {
     await Validate.log(out, settings.log);
@@ -180,6 +222,25 @@ internals.getHost = function (request) {
   }
 };
 
+internals.getServerUrl = function (request, settings) {
+  const forwardedProtocol = internals.getProxyHeader(request, 'proto');
+  const proxyHost = internals.getProxyHeader(request, 'host') || request.headers['disguised-host'] || '';
+  if (proxyHost) {
+    return `${forwardedProtocol ?? internals.getSchema(request)}://${proxyHost}${settings.basePath}`;
+  }
+
+  try {
+    const url = new URL(request.info.referrer);
+    url.search = '';
+    url.hash = '';
+    url.pathname = settings.basePath;
+    return url.toString();
+  } catch (error) {
+    // backup in case referrer isn't set for some reason. (i.e. tests)
+    return `${request.url.protocol}//${request.info.host}${settings.basePath === '/' ? '' : settings.basePath}`;
+  }
+};
+
 /**
  * finds the current schema
  *
@@ -215,7 +276,7 @@ internals.getSchema = function (request) {
  * @param  {Object} options
  * @return {Object}
  */
-internals.removeNoneSchemaOptions = function (options) {
+internals.removeNoneSchemaOptions = function (options, settings) {
   const out = Hoek.clone(options);
   [
     'debug',
@@ -252,7 +313,9 @@ internals.removeNoneSchemaOptions = function (options) {
     'validate',
     'tryItOutEnabled',
     'customSwaggerFile',
-    'wildcardMethods'
+    'wildcardMethods',
+    'OAS',
+    ...(settings.OAS === 'v2' ? [] : ['basePath', 'securityDefinitions'])
   ].forEach((element) => {
     delete out[element];
   });

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -31,15 +31,11 @@ builder.default = {
  * schema for swagger root object
  */
 builder.schema = Joi.object({
-  swagger: Joi.string()
-    .valid('2.0')
-    .required(),
+  swagger: Joi.string().valid('2.0').required(),
   info: Joi.any(),
   host: Joi.string(), // JOI hostname validator too strict
   basePath: Joi.string().regex(/^\//),
-  schemes: Joi.array()
-    .items(Joi.string().valid('http', 'https', 'ws', 'wss'))
-    .optional(),
+  schemes: Joi.array().items(Joi.string().valid('http', 'https', 'ws', 'wss')).optional(),
   consumes: Joi.array().items(Joi.string()),
   produces: Joi.array().items(Joi.string()),
   paths: Joi.any(),
@@ -132,8 +128,7 @@ builder.getSwaggerJSON = async (settings, request) => {
     return builder.dereference(out);
   }
 
-    return out;
-
+  return out;
 };
 
 /**
@@ -141,7 +136,7 @@ builder.getSwaggerJSON = async (settings, request) => {
  *
  * @param  {Object} schema
  */
-builder.dereference = async schema => {
+builder.dereference = async (schema) => {
   try {
     const json = await JSONDeRef.dereference(schema);
     delete json.definitions;
@@ -158,7 +153,7 @@ builder.dereference = async schema => {
  * @param {string} name header name (without x-forwarded prefix)
  * @return {string | undefined}
  */
-internals.getProxyHeader = function(request, name) {
+internals.getProxyHeader = function (request, name) {
   const header = request.headers['x-forwarded-' + name];
 
   return header ? header.split(',')[0] : undefined;
@@ -170,7 +165,7 @@ internals.getProxyHeader = function(request, name) {
  * @param  {Request} request
  * @return {string}
  */
-internals.getHost = function(request) {
+internals.getHost = function (request) {
   const proxyHost = internals.getProxyHeader(request, 'host') || request.headers['disguised-host'] || '';
   if (proxyHost) {
     return proxyHost;
@@ -191,7 +186,7 @@ internals.getHost = function(request) {
  * @param  {Request} request
  * @return {string}
  */
-internals.getSchema = function(request) {
+internals.getSchema = function (request) {
   const forwardedProtocol = internals.getProxyHeader(request, 'proto');
 
   if (forwardedProtocol) {
@@ -220,7 +215,7 @@ internals.getSchema = function(request) {
  * @param  {Object} options
  * @return {Object}
  */
-internals.removeNoneSchemaOptions = function(options) {
+internals.removeNoneSchemaOptions = function (options) {
   const out = Hoek.clone(options);
   [
     'debug',
@@ -258,7 +253,7 @@ internals.removeNoneSchemaOptions = function(options) {
     'tryItOutEnabled',
     'customSwaggerFile',
     'wildcardMethods'
-  ].forEach(element => {
+  ].forEach((element) => {
     delete out[element];
   });
   return out;

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -21,7 +21,7 @@ module.exports = {
   sortEndpoints: 'alpha',
   sortPaths: 'unsorted',
   grouping: 'path',
-  tagsGroupingFilter: tag => tag !== 'api',
+  tagsGroupingFilter: (tag) => tag !== 'api',
   uiCompleteScript: null,
   xProperties: true,
   reuseDefinitions: true,
@@ -31,5 +31,5 @@ module.exports = {
   validatorUrl: '//online.swagger.io/validator',
   acceptToProduce: true, // internal, NOT public
   pathReplacements: [],
-  tryItOutEnabled: false,
+  tryItOutEnabled: false
 };

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -26,6 +26,7 @@ module.exports = {
   xProperties: true,
   reuseDefinitions: true,
   wildcardMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+  OAS: 'v2',
   definitionPrefix: 'default',
   deReference: false,
   validatorUrl: '//online.swagger.io/validator',

--- a/lib/definitions.js
+++ b/lib/definitions.js
@@ -3,9 +3,12 @@ const Utilities = require('../lib/utilities');
 
 const internals = {};
 
-exports = module.exports = internals.definitions = function(settings) {
-  this.settings = settings;
-};
+exports =
+  module.exports =
+  internals.definitions =
+    function (settings) {
+      this.settings = settings;
+    };
 
 /**
  * appends a new definition object to a given collection, returns a string reference name
@@ -16,7 +19,7 @@ exports = module.exports = internals.definitions = function(settings) {
  * @param  {Object} settings
  * @return {string}
  */
-internals.definitions.prototype.append = function(definitionName, definition, currentCollection, settings) {
+internals.definitions.prototype.append = function (definitionName, definition, currentCollection, settings) {
   let out = null;
 
   definition = internals.formatProperty(definition);
@@ -57,7 +60,7 @@ internals.definitions.prototype.append = function(definitionName, definition, cu
  * @param  {Object} settings
  * @return {string}
  */
-internals.append = function(definitionName, definition, currentCollection, forceDynamicName, settings) {
+internals.append = function (definitionName, definition, currentCollection, forceDynamicName, settings) {
   let out;
   let foundDefinitionName;
 
@@ -65,7 +68,7 @@ internals.append = function(definitionName, definition, currentCollection, force
 
   // The "required" keyword is only applicable for objects not arrays
   if (definition.required && definition.items !== undefined) {
-    delete definition.required
+    delete definition.required;
   }
 
   // find definitionName by matching hash of object
@@ -99,7 +102,7 @@ internals.append = function(definitionName, definition, currentCollection, force
  * @param  {Object} obj
  * @return {Object}
  */
-internals.formatProperty = function(obj) {
+internals.formatProperty = function (obj) {
   // add $ref directly to parent and delete schema
   //    if (obj.schema) {
   //        obj.$ref = obj.schema.$ref;
@@ -122,7 +125,7 @@ internals.formatProperty = function(obj) {
  * @param  {Object} currentCollection
  * @return {string}
  */
-internals.nextModelName = function(nextModelNamePrefix, currentCollection) {
+internals.nextModelName = function (nextModelNamePrefix, currentCollection) {
   let highest = 0;
   let key;
   for (key in currentCollection) {
@@ -145,7 +148,7 @@ internals.nextModelName = function(nextModelNamePrefix, currentCollection) {
  * @param  {Object} currentCollection
  * @return {string || null}
  */
-internals.hasDefinition = function(definitionName, definition, currentCollection) {
+internals.hasDefinition = function (definitionName, definition, currentCollection) {
   const definitionSet = new Set([JSON.stringify(definition)]);
 
   for (const key in currentCollection) {

--- a/lib/group.js
+++ b/lib/group.js
@@ -13,10 +13,10 @@ const group = (module.exports = {});
  * @param  {Array} pathReplacements
  * @return {Array}
  */
-group.appendGroupByPath = function(pathPrefixSize, basePath, routes, pathReplacements) {
+group.appendGroupByPath = function (pathPrefixSize, basePath, routes, pathReplacements) {
   const out = [];
 
-  routes.forEach(route => {
+  routes.forEach((route) => {
     const prefix = group.getNameByPath(pathPrefixSize, basePath, route.path, pathReplacements);
     // append tag reference to route
     route.group = [prefix];
@@ -37,7 +37,7 @@ group.appendGroupByPath = function(pathPrefixSize, basePath, routes, pathReplace
  * @param  {Array} pathReplacements
  * @return {Array}
  */
-group.getNameByPath = function(pathPrefixSize, basePath, path, pathReplacements) {
+group.getNameByPath = function (pathPrefixSize, basePath, path, pathReplacements) {
   if (pathReplacements) {
     path = Utilities.replaceInPath(path, ['groups'], pathReplacements);
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,7 @@ const schema = Joi.object({
   xProperties: Joi.boolean(),
   reuseDefinitions: Joi.boolean(),
   wildcardMethods: Joi.array().items(Joi.string().not('HEAD', 'OPTIONS')), // OPTIONS not supported by Swagger and HEAD not support by Hapi
+  OAS: Joi.string().valid('v2', 'v3.0'),
   definitionPrefix: Joi.string(),
   deReference: Joi.boolean(),
   validatorUrl: Joi.string().allow(null),
@@ -96,6 +97,11 @@ exports.plugin = {
     // avoid breaking behaviour with previous version
     if (!options.routesBasePath && options.swaggerUIPath) {
       settings.routesBasePath = options.swaggerUIPath;
+    }
+
+    if (options.OAS === 'v3.0') {
+      settings.jsonPath = options.jsonPath || '/openapi.json';
+      settings.jsonRoutePath = options.jsonRoutePath || '/openapi.json';
     }
 
     if (!options.jsonRoutePath && options.jsonPath) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,9 +21,7 @@ const schema = Joi.object({
   swaggerUIPath: Joi.string(),
   routesBasePath: Joi.string(),
   auth: Joi.alternatives().try(Joi.boolean(), Joi.string(), Joi.object()),
-  pathPrefixSize: Joi.number()
-    .integer()
-    .positive(),
+  pathPrefixSize: Joi.number().integer().positive(),
   payloadType: Joi.string().valid('form', 'json'),
   documentationPage: Joi.boolean(),
   swaggerUI: Joi.boolean(),
@@ -39,14 +37,13 @@ const schema = Joi.object({
   //        eg: '/assets/js/doc-patch.js'
   uiCompleteScript: Joi.alternatives(
     Joi.string(),
-    Joi.object()
-      .keys({
-        src: Joi.string().required()
-      })
+    Joi.object().keys({
+      src: Joi.string().required()
+    })
   ).allow(null),
   xProperties: Joi.boolean(),
   reuseDefinitions: Joi.boolean(),
-  wildcardMethods: Joi.array().items(Joi.string().not('HEAD', 'OPTIONS')),  // OPTIONS not supported by Swagger and HEAD not support by Hapi
+  wildcardMethods: Joi.array().items(Joi.string().not('HEAD', 'OPTIONS')), // OPTIONS not supported by Swagger and HEAD not support by Hapi
   definitionPrefix: Joi.string(),
   deReference: Joi.boolean(),
   validatorUrl: Joi.string().allow(null),
@@ -68,15 +65,12 @@ const schema = Joi.object({
     query: Joi.alternatives(Joi.object(), Joi.array(), Joi.function()).allow(null, false, true),
     payload: Joi.alternatives(Joi.object(), Joi.array(), Joi.function()).allow(null, false, true),
     state: Joi.alternatives(Joi.object(), Joi.array(), Joi.function()).allow(null, false, true),
-    failAction: Joi.alternatives([
-      Joi.valid('error', 'log', 'ignore'),
-      Joi.function()
-    ]),
+    failAction: Joi.alternatives([Joi.valid('error', 'log', 'ignore'), Joi.function()]),
     errorFields: Joi.object(),
     options: Joi.object(),
     validator: Joi.object()
   }),
-  tryItOutEnabled: Joi.boolean(),
+  tryItOutEnabled: Joi.boolean()
 }).unknown();
 
 /**
@@ -95,7 +89,7 @@ exports.plugin = {
     // `options.validate` might not be present but it should not be set in the
     // `Defaults` since it would always override the server-level defaults.
     // It should be overwritten only if explicitly passed to the plugin options.
-    const validateOption = { validate: options.validate }
+    const validateOption = { validate: options.validate };
     const settings = Hoek.applyToDefaults(Defaults, options, { nullOverride: true });
     const publicDirPath = Path.resolve(__dirname, '..', 'public');
 
@@ -140,9 +134,9 @@ exports.plugin = {
     // patch: uiCompleteScript -- Implementing
     //        mutate the uiCompleteScript before render into h.views
     if (
-      (settings.uiCompleteScript !== '') &&
-      (settings.uiCompleteScript !== null) &&
-      (typeof settings.uiCompleteScript === 'object')
+      settings.uiCompleteScript !== '' &&
+      settings.uiCompleteScript !== null &&
+      typeof settings.uiCompleteScript === 'object'
     ) {
       settings.uiCompleteScript = `
         const s = document.createElement('script');
@@ -159,31 +153,33 @@ exports.plugin = {
       {
         method: 'GET',
         path: settings.jsonRoutePath,
-        options: Hoek.applyToDefaults({
-          auth: settings.auth,
-          cors: settings.cors,
-          tags: settings.documentationRouteTags,
-          handler: async (request, h) => {
-            if (settings.cache) {
-              const { cached, value } = await server.methods.getSwaggerJSON(settings, request);
-              const lastModified = cached ? new Date(cached.stored) : new Date();
-              return h.response(value).header('last-modified', lastModified.toUTCString());
-            }
+        options: Hoek.applyToDefaults(
+          {
+            auth: settings.auth,
+            cors: settings.cors,
+            tags: settings.documentationRouteTags,
+            handler: async (request, h) => {
+              if (settings.cache) {
+                const { cached, value } = await server.methods.getSwaggerJSON(settings, request);
+                const lastModified = cached ? new Date(cached.stored) : new Date();
+                return h.response(value).header('last-modified', lastModified.toUTCString());
+              }
 
               const json = await Builder.getSwaggerJSON(settings, request);
               return json;
-
+            },
+            plugins: {
+              'hapi-swagger': false
+            }
           },
-          plugins: {
-            'hapi-swagger': false
-          }
-        }, validateOption)
+          validateOption
+        )
       }
     ]);
 
     // only add '@hapi/inert' and '@hapi/vision' based routes if needed
     if (settings.documentationPage === true || settings.swaggerUI === true) {
-      server.dependency(['@hapi/inert', '@hapi/vision'], server => {
+      server.dependency(['@hapi/inert', '@hapi/vision'], (server) => {
         // Setup vision using handlebars from the templates directory
         server.views({
           engines: {
@@ -198,14 +194,17 @@ exports.plugin = {
             {
               method: 'GET',
               path: settings.documentationPath,
-              options: Hoek.applyToDefaults({
-                auth: settings.auth,
-                tags: settings.documentationRouteTags,
-                handler: (request, h) => {
-                  return h.view('index', {});
+              options: Hoek.applyToDefaults(
+                {
+                  auth: settings.auth,
+                  tags: settings.documentationRouteTags,
+                  handler: (request, h) => {
+                    return h.view('index', {});
+                  },
+                  plugins: settings.documentationRoutePlugins
                 },
-                plugins: settings.documentationRoutePlugins
-              }, validateOption)
+                validateOption
+              )
             }
           ]);
         }
@@ -226,17 +225,20 @@ exports.plugin = {
             'swagger-ui.js',
             'swagger-ui.js.map'
           ];
-          filesToServe.forEach(filename => {
+          filesToServe.forEach((filename) => {
             server.route({
               method: 'GET',
               path: `${settings.routesBasePath}${filename}`,
-              options: Hoek.applyToDefaults({
-                auth: settings.auth,
-                tags: settings.documentationRouteTags,
-                files: {
-                  relativeTo: swaggerUiAssetPath
-                }
-              }, validateOption),
+              options: Hoek.applyToDefaults(
+                {
+                  auth: settings.auth,
+                  tags: settings.documentationRouteTags,
+                  files: {
+                    relativeTo: swaggerUiAssetPath
+                  }
+                },
+                validateOption
+              ),
               handler: {
                 file: `${filename}`
               }
@@ -246,16 +248,19 @@ exports.plugin = {
           server.route({
             method: 'GET',
             path: settings.routesBasePath + 'extend.js',
-            options: Hoek.applyToDefaults({
-              tags: settings.documentationRouteTags,
-              auth: settings.auth,
-              files: {
-                relativeTo: publicDirPath
+            options: Hoek.applyToDefaults(
+              {
+                tags: settings.documentationRouteTags,
+                auth: settings.auth,
+                files: {
+                  relativeTo: publicDirPath
+                },
+                handler: {
+                  file: 'extend.js'
+                }
               },
-              handler: {
-                file: 'extend.js'
-              }
-            }, validateOption)
+              validateOption
+            )
           });
         }
 
@@ -264,17 +269,18 @@ exports.plugin = {
           server.route([
             {
               method: 'GET',
-              path: join(settings.documentationPath, sep, 'debug')
-                .split(sep)
-                .join('/'),
-              options: Hoek.applyToDefaults({
-                auth: settings.auth,
-                tags: settings.documentationRouteTags,
-                handler: (request, h) => {
-                  return h.view('debug.html', {}).type('application/json');
+              path: join(settings.documentationPath, sep, 'debug').split(sep).join('/'),
+              options: Hoek.applyToDefaults(
+                {
+                  auth: settings.auth,
+                  tags: settings.documentationRouteTags,
+                  handler: (request, h) => {
+                    return h.view('debug.html', {}).type('application/json');
+                  },
+                  plugins: settings.documentationRoutePlugins
                 },
-                plugins: settings.documentationRoutePlugins
-              }, validateOption)
+                validateOption
+              )
             }
           ]);
         }
@@ -367,7 +373,7 @@ const findAPIKeyPrefix = function (settings) {
   /* $lab:coverage:off$ */
   let out = '';
   if (settings.securityDefinitions) {
-    Object.keys(settings.securityDefinitions).forEach(key => {
+    Object.keys(settings.securityDefinitions).forEach((key) => {
       if (settings.securityDefinitions[key]['x-keyPrefix']) {
         out = settings.securityDefinitions[key]['x-keyPrefix'];
       }

--- a/lib/info.js
+++ b/lib/info.js
@@ -36,7 +36,7 @@ info.schema = Joi.object({
  * @param  {Object} options
  * @return {Object}
  */
-info.build = function(options) {
+info.build = function (options) {
   const out = options.info ? Hoek.applyToDefaults(info.defaults, options.info) : info.defaults;
   Joi.assert(out, info.schema);
   return out;

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -58,9 +58,10 @@ parameters.itemsObjectProperties = [
  *
  * @param  {Object} schemaObj
  * @param  {string} parameterType
+ * @param  {Object} settings
  * @return {Object}
  */
-parameters.fromProperties = function (schemaObj, parameterType) {
+parameters.fromProperties = function (schemaObj, parameterType, settings) {
   const out = [];
   // if (this.allowedParameterTypes.indexOf(parameterType) === -1) {
   //     return out;
@@ -108,8 +109,26 @@ parameters.fromProperties = function (schemaObj, parameterType) {
         return;
       }
 
-      item.name = key;
-      item.in = parameterType;
+      if (settings.OAS === 'v2') {
+        item.name = key;
+        item.in = parameterType;
+      } else {
+        const description = item.description;
+        item = {
+          name: key,
+          in: parameterType,
+          schema: item
+        };
+
+        if (description) {
+          item.description = description;
+        }
+
+        if (item.schema.type === 'array') {
+          item.style = 'form';
+          item.explode = true;
+        }
+      }
 
       // reinstate required at parameter level
       delete item.required;
@@ -121,10 +140,14 @@ parameters.fromProperties = function (schemaObj, parameterType) {
         item.required = false;
       }
 
-      // object is not a valid parameter type in v2.0, replacing it with string
-      this.replaceObjectsWithStrings(item);
+      if (settings.OAS === 'v2') {
+        // object is not a valid parameter type in v2.0, replacing it with string
+        this.replaceObjectsWithStrings(item);
+        item = this.removePropsRecursively(item);
+      } else {
+        item = this.removePropsRecursively(item, this.allowedProps.concat(['explode', 'style']));
+      }
 
-      item = this.removePropsRecursively(item);
       out.push(item);
     });
   }

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -33,7 +33,25 @@ parameters.allowedProps = [
 // add none swagger property needed to flag touched state of required property
 parameters.allowedProps.push('optional');
 
-parameters.itemsObjectProperties = ['type', 'format', 'items', 'collectionFormat', 'default', 'maximum', 'exclusiveMaximum', 'minimum', 'exclusiveMinimum', 'maxLength', 'minLength', 'pattern', 'maxItems', 'minItems', 'uniqueItems', 'enum', 'multipleOf'];
+parameters.itemsObjectProperties = [
+  'type',
+  'format',
+  'items',
+  'collectionFormat',
+  'default',
+  'maximum',
+  'exclusiveMaximum',
+  'minimum',
+  'exclusiveMinimum',
+  'maxLength',
+  'minLength',
+  'pattern',
+  'maxItems',
+  'minItems',
+  'uniqueItems',
+  'enum',
+  'multipleOf'
+];
 
 /**
  * takes a swagger schema object and returns a parameters object
@@ -42,7 +60,7 @@ parameters.itemsObjectProperties = ['type', 'format', 'items', 'collectionFormat
  * @param  {string} parameterType
  * @return {Object}
  */
-parameters.fromProperties = function(schemaObj, parameterType) {
+parameters.fromProperties = function (schemaObj, parameterType) {
   const out = [];
   // if (this.allowedParameterTypes.indexOf(parameterType) === -1) {
   //     return out;
@@ -83,11 +101,10 @@ parameters.fromProperties = function(schemaObj, parameterType) {
 
     // if its an array of parameters
   } else {
-
     Object.keys(schemaObj.properties).forEach((key) => {
       let item = schemaObj.properties[key];
 
-      if (typeof item === 'undefined' ) {
+      if (typeof item === 'undefined') {
         return;
       }
 
@@ -116,22 +133,24 @@ parameters.fromProperties = function(schemaObj, parameterType) {
 };
 
 parameters.replaceObjectsWithStrings = function (item) {
-  if(item.type === 'object'){
+  if (item.type === 'object') {
     item.type = 'string';
     item['x-type'] = 'object';
-    Utilities.findAndRenameKey(item, 'properties', 'x-properties')
+    Utilities.findAndRenameKey(item, 'properties', 'x-properties');
   }
 
-  if(item.items){ // repeat for array items
+  if (item.items) {
+    // repeat for array items
     this.replaceObjectsWithStrings(item.items);
   }
-}
+};
 
-parameters.removePropsRecursively = function (item, props=this.allowedProps){
+parameters.removePropsRecursively = function (item, props = this.allowedProps) {
   item = Utilities.removeProps(item, props);
-  if(item.items){ // repeat for array items
-    this.removePropsRecursively(item.items, this.itemsObjectProperties)
+  if (item.items) {
+    // repeat for array items
+    this.removePropsRecursively(item.items, this.itemsObjectProperties);
   }
 
   return item;
-}
+};

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -161,12 +161,26 @@ internals.getMultiMethodRoutes = function (route, wildcardMethods) {
 };
 
 /**
- * build the swagger path section from hapi routes data
+ * build the path section from hapi routes data
  *
  * @param  {Array} routes
  * @return {Object}
  */
 internals.paths.prototype.buildRoutes = function (routes) {
+  if (this.settings.OAS === 'v2') {
+    return this.buildSwaggerRoutes(routes);
+  }
+
+  return this.buildOpenApiRoutes(routes);
+};
+
+/**
+ * build the swagger path section from hapi routes data
+ *
+ * @param  {Array} routes
+ * @return {Object}
+ */
+internals.paths.prototype.buildSwaggerRoutes = function (routes) {
   const self = this;
   const pathObj = {};
   const swagger = {
@@ -313,7 +327,7 @@ internals.paths.prototype.buildRoutes = function (routes) {
       payloadStructures.parameters
     );
 
-    // if the api sets the content-type header pramater use that
+    // if the api sets the content-type header parameter use that
     if (internals.hasContentTypeHeader(out)) {
       delete out.consumes;
     }
@@ -344,6 +358,204 @@ internals.paths.prototype.buildRoutes = function (routes) {
 };
 
 /**
+ * build the OpenAPI path section from hapi routes data
+ *
+ * @param  {Array} routes
+ * @return {Object}
+ */
+internals.paths.prototype.buildOpenApiRoutes = function (routes) {
+  const pathObj = {};
+  const openApi = {
+    definitions: {},
+    'x-alt-definitions': {}
+  };
+  const definitionCache = [new WeakMap(), new WeakMap()];
+
+  // reset properties
+  this.properties = new Properties(this.settings, openApi.definitions, openApi['x-alt-definitions'], definitionCache);
+  this.responses = new Responses(this.settings, openApi.definitions, openApi['x-alt-definitions'], definitionCache);
+
+  routes.forEach((route) => {
+    const method = route.method;
+    let path = internals.removeBasePath(route.path, this.settings.basePath, this.settings.pathReplacements);
+    const out = {
+      summary: route.description,
+      operationId: route.id || Utilities.createId(route.method, path),
+      description: route.notes,
+      parameters: []
+    };
+
+    // tags in swagger are used for grouping
+    if (this.settings.grouping === 'tags') {
+      out.tags = (route.tags || []).filter(this.settings.tagsGroupingFilter);
+    } else {
+      out.tags = route.groups;
+    }
+
+    out.description = Array.isArray(route.notes) ? route.notes.join('<br/><br/>') : route.notes;
+
+    if (route.security) {
+      out.security = route.security;
+    }
+
+    // add user defined over automatically discovered
+    let consumes = internals.overload(this.settings.consumes, route.consumes);
+    let produces = internals.overload(this.settings.produces, route.produces) || ['application/json'];
+
+    // set from plugin options or from route options
+    const payloadType = internals.overload(this.settings.payloadType, route.payloadType);
+
+    // build payload either with JSON or form input
+    const payloadJoi = route.payloadParams;
+    if (payloadType.toLowerCase() === 'json') {
+      const schema = this.getSwaggerStructures(payloadJoi, 'body', true, false).properties;
+      if (schema && Object.keys(schema).length > 0) {
+        out.requestBody = {
+          content: Object.fromEntries((consumes || ['application/json']).map((c) => [c, { schema }]))
+        };
+      }
+    } else {
+      // add form data mimetype
+      if (!consumes || consumes.length === 0) {
+        // change form mimetype based on meta property 'swaggerType'
+        consumes = internals.hasFileType(route) ? ['multipart/form-data'] : ['application/x-www-form-urlencoded'];
+      }
+
+      // set as formData
+      if (Utilities.hasJoiChildren(payloadJoi)) {
+        const schema = this.getSwaggerStructures(payloadJoi, 'formData', false, false).properties;
+        out.requestBody = {
+          content: Object.fromEntries(consumes.map((c) => [c, { schema }]))
+        };
+      } else {
+        this.testParameterError(payloadJoi, 'payload form-urlencoded', path);
+      }
+    }
+
+    // set required true/false for each path params
+    let pathStructures = this.getDefaultStructures();
+    const pathJoi = route.pathParams;
+    if (Utilities.hasJoiChildren(pathJoi)) {
+      pathStructures = this.getSwaggerStructures(pathJoi, 'path', false, false);
+      pathStructures.parameters.forEach((item) => {
+        // add required based on path pattern {prama} and {prama?}
+        if (item.required === undefined) {
+          if (path.indexOf('{' + item.name + '}') > -1) {
+            item.required = true;
+          }
+
+          if (path.indexOf('{' + item.name + '?}') > -1) {
+            delete item.required;
+          }
+        }
+
+        if (item.required === false) {
+          delete item.required;
+        }
+
+        if (!item.required) {
+          this.settings.log(
+            ['validation', 'warning'],
+            'The ' +
+              path +
+              ' params parameter {' +
+              item.name +
+              '} is set as optional. This will work in the UI, but is invalid in the swagger spec'
+          );
+        }
+      });
+    } else {
+      this.testParameterError(pathJoi, 'params', path);
+    }
+
+    // removes ? from {prama?} after we have set required/optional for path params
+    path = internals.cleanPathParameters(path);
+
+    let headerStructures = this.getDefaultStructures();
+    const headerJoi = route.headerParams;
+    if (Utilities.hasJoiChildren(headerJoi)) {
+      headerStructures = this.getSwaggerStructures(headerJoi, 'header', false, false);
+    } else {
+      this.testParameterError(headerJoi, 'headers', path);
+    }
+
+    // if the API has a user set accept header with a enum convert into the produces array
+    if (this.settings.acceptToProduce === true) {
+      headerStructures.parameters = headerStructures.parameters.filter((header) => {
+        if (header.name.toLowerCase() === 'accept') {
+          if (header.schema.enum) {
+            produces = Utilities.sortFirstItem(header.schema.enum, header.default);
+            return false;
+          }
+        }
+
+        return true;
+      });
+    }
+
+    let queryStructures = this.getDefaultStructures();
+    const queryJoi = route.queryParams;
+    if (Utilities.hasJoiChildren(queryJoi)) {
+      queryStructures = this.getSwaggerStructures(queryJoi, 'query', false, false);
+    } else {
+      this.testParameterError(queryJoi, 'query', path);
+    }
+
+    out.parameters = out.parameters.concat(
+      headerStructures.parameters,
+      pathStructures.parameters,
+      queryStructures.parameters
+    );
+
+    // if the api sets the content-type header parameter use that
+    if (internals.hasContentTypeHeader(out)) {
+      delete out.consumes;
+    }
+
+    //const name = out.operationId + method;
+    //userDefindedSchemas, defaultSchema, statusSchemas, useDefinitions, isAlt
+    const responses = this.responses.build(route.responses, route.responseSchema, route.responseStatus, true, false);
+    out.responses = Object.fromEntries(
+      Object.entries(responses).map(([response, { schema, examples, ...definition }]) => [
+        response,
+        Object.assign(
+          definition,
+          schema
+            ? {
+                content: Object.fromEntries(
+                  produces.map((mimeType) => [
+                    mimeType,
+                    Object.assign({ schema }, examples ? { example: examples } : {})
+                  ])
+                )
+              }
+            : {}
+        )
+      ])
+    );
+
+    if (route.order) {
+      out['x-order'] = route.order;
+    }
+
+    Utilities.assignVendorExtensions(out, route);
+
+    if (route.deprecated !== null) {
+      out.deprecated = route.deprecated;
+    }
+
+    if (!pathObj[path]) {
+      pathObj[path] = {};
+    }
+
+    pathObj[path][method.toLowerCase()] = Utilities.deleteEmptyProperties(out);
+  });
+
+  openApi.paths = pathObj;
+  return openApi;
+};
+
+/**
  * overload one object with another
  *
  * @param  {Object} base
@@ -351,7 +563,7 @@ internals.paths.prototype.buildRoutes = function (routes) {
  * @return {Object}
  */
 internals.overload = function (base, priority) {
-  return priority ? priority : base;
+  return priority || base;
 };
 
 /**
@@ -423,7 +635,7 @@ internals.paths.prototype.getSwaggerStructures = function (joiObj, parameterType
   if (joiObj) {
     // name, joiObj, parent, parameterType, useDefinitions, isAlt
     outProperties = this.properties.parseProperty(null, joiObj, null, parameterType, useDefinitions, isAlt);
-    outParameters = Parameters.fromProperties(outProperties, parameterType);
+    outParameters = Parameters.fromProperties(outProperties, parameterType, this.settings);
   }
 
   return {

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -9,34 +9,37 @@ const Utilities = require('../lib/utilities');
 
 const internals = {};
 
-exports = module.exports = internals.paths = function(settings) {
-  this.settings = settings;
-  this.definitions = new Definitions(settings);
-  this.properties = new Properties(settings, {}, {});
-  this.responses = new Responses(settings, {}, {});
+exports =
+  module.exports =
+  internals.paths =
+    function (settings) {
+      this.settings = settings;
+      this.definitions = new Definitions(settings);
+      this.properties = new Properties(settings, {}, {});
+      this.responses = new Responses(settings, {}, {});
 
-  this.defaults = {
-    responses: {}
-  };
+      this.defaults = {
+        responses: {}
+      };
 
-  this.schema = Joi.object({
-    tags: Joi.array().items(Joi.string()),
-    summary: Joi.string(),
-    description: Joi.string(),
-    externalDocs: Joi.object({
-      description: Joi.string(),
-      url: Joi.string().uri()
-    }),
-    operationId: Joi.string(),
-    consumes: Joi.array().items(Joi.string()),
-    produces: Joi.array().items(Joi.string()),
-    parameters: Joi.array().items(Joi.object()),
-    responses: Joi.object().required(),
-    schemes: Joi.array().items(Joi.string().valid('http', 'https', 'ws', 'wss')),
-    deprecated: Joi.boolean(),
-    security: Joi.array().items(Joi.object())
-  });
-};
+      this.schema = Joi.object({
+        tags: Joi.array().items(Joi.string()),
+        summary: Joi.string(),
+        description: Joi.string(),
+        externalDocs: Joi.object({
+          description: Joi.string(),
+          url: Joi.string().uri()
+        }),
+        operationId: Joi.string(),
+        consumes: Joi.array().items(Joi.string()),
+        produces: Joi.array().items(Joi.string()),
+        parameters: Joi.array().items(Joi.object()),
+        responses: Joi.object().required(),
+        schemes: Joi.array().items(Joi.string().valid('http', 'https', 'ws', 'wss')),
+        deprecated: Joi.boolean(),
+        security: Joi.array().items(Joi.object())
+      });
+    };
 
 /**
  * build the swagger path section
@@ -44,13 +47,13 @@ exports = module.exports = internals.paths = function(settings) {
  * @param  {Array} routes
  * @return {Object}
  */
-internals.paths.prototype.build = function(routes) {
+internals.paths.prototype.build = function (routes) {
   const self = this;
 
   const routesData = [];
 
   // loop each route
-  routes.forEach(route => {
+  routes.forEach((route) => {
     const routeOptions = Hoek.reach(route, 'settings.plugins.hapi-swagger') || {};
     const routeData = internals.createRouteMetaData(route, routeOptions);
 
@@ -89,10 +92,10 @@ internals.paths.prototype.build = function(routes) {
             'Using a Joi.function for a query, header or payload is not supported.'
           );
 
-          routeData[property] = property === 'payloadParams'
-            ? Joi.object().label('Hidden Model')
-            : Joi.object({ 'Hidden Model': Joi.string() });
-
+          routeData[property] =
+            property === 'payloadParams'
+              ? Joi.object().label('Hidden Model')
+              : Joi.object({ 'Hidden Model': Joi.string() });
         } else {
           self.settings.log(
             ['validation', 'error'],
@@ -115,7 +118,7 @@ internals.paths.prototype.build = function(routes) {
  * @param {Object} routeOptions
  * @returns {Object}
  */
-internals.createRouteMetaData = function(route, routeOptions) {
+internals.createRouteMetaData = function (route, routeOptions) {
   return {
     path: route.path,
     method: route.method.toUpperCase(),
@@ -138,7 +141,7 @@ internals.createRouteMetaData = function(route, routeOptions) {
     id: Hoek.reach(routeOptions, 'id') || null,
     groups: route.group
   };
-}
+};
 
 /**
  * Handle the case when route's method is declared with wildcard syntax
@@ -146,16 +149,16 @@ internals.createRouteMetaData = function(route, routeOptions) {
  * @param {Array<string>} wildcardMethods
  * @returns {*[]}
  */
-internals.getMultiMethodRoutes = function(route, wildcardMethods) {
+internals.getMultiMethodRoutes = function (route, wildcardMethods) {
   return route.method !== '*'
     ? [Hoek.clone(route)]
     : wildcardMethods.map((method) => {
-      return {
-        ...Hoek.clone(route),
-        method
-      };
-    });
-}
+        return {
+          ...Hoek.clone(route),
+          method
+        };
+      });
+};
 
 /**
  * build the swagger path section from hapi routes data
@@ -163,7 +166,7 @@ internals.getMultiMethodRoutes = function(route, wildcardMethods) {
  * @param  {Array} routes
  * @return {Object}
  */
-internals.paths.prototype.buildRoutes = function(routes) {
+internals.paths.prototype.buildRoutes = function (routes) {
   const self = this;
   const pathObj = {};
   const swagger = {
@@ -176,7 +179,7 @@ internals.paths.prototype.buildRoutes = function(routes) {
   this.properties = new Properties(this.settings, swagger.definitions, swagger['x-alt-definitions'], definitionCache);
   this.responses = new Responses(this.settings, swagger.definitions, swagger['x-alt-definitions'], definitionCache);
 
-  routes.forEach(route => {
+  routes.forEach((route) => {
     const method = route.method;
     let path = internals.removeBasePath(route.path, this.settings.basePath, this.settings.pathReplacements);
     const out = {
@@ -230,9 +233,7 @@ internals.paths.prototype.buildRoutes = function(routes) {
       // add form data mimetype
       if (out.consumes.length === 0) {
         // change form mimetype based on meta property 'swaggerType'
-        out.consumes = internals.hasFileType(route)
-          ? ['multipart/form-data']
-          : ['application/x-www-form-urlencoded'];
+        out.consumes = internals.hasFileType(route) ? ['multipart/form-data'] : ['application/x-www-form-urlencoded'];
       }
     }
 
@@ -349,7 +350,7 @@ internals.paths.prototype.buildRoutes = function(routes) {
  * @param  {Object} priority
  * @return {Object}
  */
-internals.overload = function(base, priority) {
+internals.overload = function (base, priority) {
   return priority ? priority : base;
 };
 
@@ -359,7 +360,7 @@ internals.overload = function(base, priority) {
  * @param  {Object} route
  * @return {Boolean}
  */
-internals.hasFileType = function(route) {
+internals.hasFileType = function (route) {
   const payloadParamsString = JSON.stringify(route.payloadParams, (key, value) => {
     // _currentJoi is a circular reference, introduced in Joi v11.0.0
     return key === '_currentJoi' ? undefined : value;
@@ -373,7 +374,7 @@ internals.hasFileType = function(route) {
  * @param  {string} path
  * @return {string}
  */
-internals.cleanPathParameters = function(path) {
+internals.cleanPathParameters = function (path) {
   return path.replace('?}', '}');
 };
 
@@ -385,7 +386,7 @@ internals.cleanPathParameters = function(path) {
  * @param  {Array} pathReplacements
  * @return {string}
  */
-internals.removeBasePath = function(path, basePath, pathReplacements) {
+internals.removeBasePath = function (path, basePath, pathReplacements) {
   if (basePath !== '/' && path.startsWith(basePath)) {
     path = path.replace(basePath, '');
     path = Utilities.replaceInPath(path, ['endpoints'], pathReplacements);
@@ -400,8 +401,10 @@ internals.removeBasePath = function(path, basePath, pathReplacements) {
  * @param  {string} path
  * @return {boolean}
  */
-internals.hasContentTypeHeader = function(path) {
-  return path.parameters.some((parameter) => parameter.in === 'header' && parameter.name.toLowerCase() === 'content-type');
+internals.hasContentTypeHeader = function (path) {
+  return path.parameters.some(
+    (parameter) => parameter.in === 'header' && parameter.name.toLowerCase() === 'content-type'
+  );
 };
 
 /**
@@ -413,7 +416,7 @@ internals.hasContentTypeHeader = function(path) {
  * @param  {Boolean} isAlt
  * @return {Object}
  */
-internals.paths.prototype.getSwaggerStructures = function(joiObj, parameterType, useDefinitions, isAlt) {
+internals.paths.prototype.getSwaggerStructures = function (joiObj, parameterType, useDefinitions, isAlt) {
   let outProperties;
   let outParameters;
 
@@ -429,14 +432,14 @@ internals.paths.prototype.getSwaggerStructures = function(joiObj, parameterType,
   };
 };
 
-internals.paths.prototype.getDefaultStructures = function() {
+internals.paths.prototype.getDefaultStructures = function () {
   return {
     properties: {},
     parameters: []
   };
 };
 
-internals.paths.prototype.testParameterError = function(joiObj, parameterType, path) {
+internals.paths.prototype.testParameterError = function (joiObj, parameterType, path) {
   if (joiObj && !Utilities.hasJoiChildren(joiObj)) {
     this.settings.log(
       ['validation', 'error'],

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -137,6 +137,10 @@ internals.properties.prototype.parseProperty = function (name, joiObj, parent, p
     if (enums.length > 0) {
       property.enum = enums;
     }
+
+    if (this.settings.OAS === 'v3.0' && describe.allow.some((item) => item === null)) {
+      property.nullable = true;
+    }
   }
 
   // add number properties
@@ -260,7 +264,7 @@ internals.properties.prototype.setRequiredAndOptionalOnParent = function (name, 
       parent.required = [];
     }
 
-    if (parent.optional === undefined) {
+    if (this.settings.OAS === 'v2' && parent.optional === undefined) {
       parent.optional = [];
     }
 
@@ -270,7 +274,7 @@ internals.properties.prototype.setRequiredAndOptionalOnParent = function (name, 
       }
     }
 
-    if (Hoek.reach(joiObj, '_flags.presence') === 'optional') {
+    if (this.settings.OAS === 'v2' && Hoek.reach(joiObj, '_flags.presence') === 'optional') {
       if (!parent.optional.includes(name)) {
         parent.optional.push(name);
       }
@@ -333,11 +337,17 @@ internals.properties.prototype.parsePropertyMetadata = function (property, name,
 
   this.setRequiredAndOptionalOnParent(name, parent, joiObj);
 
-  property.default = Hoek.reach(joiObj, '_flags.default');
+  let propertyDefault = Hoek.reach(joiObj, '_flags.default');
 
   // allow for function calls
-  if (Utilities.isFunction(property.default)) {
-    property.default = property.default();
+  if (Utilities.isFunction(propertyDefault)) {
+    propertyDefault = propertyDefault();
+  }
+
+  if (property.type === 'array' && Array.isArray(propertyDefault) && propertyDefault.length === 0) {
+    // Default should not be set for empty arrays
+  } else {
+    property.default = propertyDefault;
   }
 
   return property;
@@ -475,18 +485,19 @@ internals.properties.prototype.parseObject = function (property, joiObj, name, p
     }
 
     //name, joiObj, parent, parameterType, useDefinitions, isAlt
-    property.properties[keyName] = this.parseProperty(
-      itemName,
-      joiChildObj,
-      property,
-      parameterType,
-      useDefinitions,
-      isAlt
-    );
+    const parsedProperty = this.parseProperty(itemName, joiChildObj, property, parameterType, useDefinitions, isAlt);
+    if (parsedProperty) {
+      delete parsedProperty.name;
+      property.properties[keyName] = parsedProperty;
+    }
+
     // switch references if naming has changed
     if (keyName !== itemName) {
       property.required = Utilities.replaceValue(property.required, itemName, keyName);
-      property.optional = Utilities.replaceValue(property.optional, itemName, keyName);
+
+      if (this.settings.OAS === 'v2') {
+        property.optional = Utilities.replaceValue(property.optional, itemName, keyName);
+      }
     }
   });
   return property;
@@ -527,7 +538,7 @@ internals.properties.prototype.parseArray = function (property, joiObj, name, pa
   };
 
   // set swaggers collectionFormat to one that works with hapi
-  if (parameterType === 'query' || parameterType === 'formData') {
+  if ((parameterType === 'query' || parameterType === 'formData') && this.settings.OAS === 'v2') {
     property.collectionFormat = 'multi';
   }
 
@@ -570,54 +581,68 @@ internals.properties.prototype.parseArray = function (property, joiObj, name, pa
  * @return {Object}
  */
 internals.properties.prototype.parseAlternatives = function (property, joiObj, name, parameterType, useDefinitions) {
+  const buildAlternativesArray = (schemas) => {
+    return schemas
+      .map((schema) => {
+        const childMetaName = Utilities.getJoiMetaProperty(schema, 'swaggerLabel');
+        const altName = childMetaName || Utilities.getJoiLabel(schema) || name;
+        //name, joiObj, parent, parameterType, useDefinitions, isAlt
+        return this.parseProperty(altName, schema, property, parameterType, useDefinitions, true);
+      })
+      .filter((obj) => obj);
+  };
+
   // convert .try() alternatives structures
   if (Hoek.reach(joiObj, '$_terms.matches.0.schema')) {
-    // add first into definitionCollection
-    const child = joiObj.$_terms.matches[0].schema;
-    const childName = Utilities.getJoiLabel(joiObj);
-    //name, joiObj, parent, parameterType, useDefinitions, isAlt
-    property = this.parseProperty(childName, child, property, parameterType, useDefinitions, false);
+    if (this.settings.OAS === 'v2') {
+      // add first into definitionCollection
+      const child = joiObj.$_terms.matches[0].schema;
+      const childName = Utilities.getJoiLabel(joiObj);
+      //name, joiObj, parent, parameterType, useDefinitions, isAlt
+      property = this.parseProperty(childName, child, property, parameterType, useDefinitions, false);
 
-    // create the alternatives without appending to the definitionCollection
-    // if (property && this.settings.xProperties === true) {
-    if (this.settings.xProperties === true) {
-      const altArray = joiObj.$_terms.matches
-        .map((obj) => {
-          const childMetaName = Utilities.getJoiMetaProperty(obj.schema, 'swaggerLabel');
-          const altName = childMetaName || Utilities.getJoiLabel(obj.schema) || name;
-
-          //name, joiObj, parent, parameterType, useDefinitions, isAlt
-          return this.parseProperty(altName, obj.schema, property, parameterType, useDefinitions, true);
-        })
-        .filter((obj) => obj);
-      property['x-alternatives'] = Hoek.clone(altArray);
+      // create the alternatives without appending to the definitionCollection
+      // if (property && this.settings.xProperties === true) {
+      if (this.settings.xProperties === true) {
+        const altArray = buildAlternativesArray(joiObj.$_terms.matches.map((obj) => obj.schema));
+        property['x-alternatives'] = Hoek.clone(altArray);
+      }
+    } else {
+      property.anyOf = buildAlternativesArray(joiObj.$_terms.matches.map((obj) => obj.schema));
+      delete property.type;
     }
   }
 
   // convert .when() alternatives structures
   else {
-    // add first into definitionCollection
-    const child = joiObj.$_terms.matches[0].then;
-    const childMetaName = Utilities.getJoiMetaProperty(child, 'swaggerLabel');
-    const childName = childMetaName || Utilities.getJoiLabel(child) || name;
-    //name, joiObj, parent, parameterType, useDefinitions, isAlt
-    property = this.parseProperty(childName, child, property, parameterType, useDefinitions, false);
+    if (this.settings.OAS === 'v2') {
+      // add first into definitionCollection
+      const child = joiObj.$_terms.matches[0].then;
+      const childMetaName = Utilities.getJoiMetaProperty(child, 'swaggerLabel');
+      const childName = childMetaName || Utilities.getJoiLabel(child) || name;
+      //name, joiObj, parent, parameterType, useDefinitions, isAlt
+      property = this.parseProperty(childName, child, property, parameterType, useDefinitions, false);
 
-    // create the alternatives without appending to the definitionCollection
-    if (property && this.settings.xProperties === true) {
-      const altArray = joiObj.$_terms.matches
-        .reduce((res, obj) => {
+      // create the alternatives without appending to the definitionCollection
+      if (property && this.settings.xProperties === true) {
+        const altArray = buildAlternativesArray(
+          joiObj.$_terms.matches.reduce((res, obj) => {
+            obj.then && res.push(obj.then);
+            obj.otherwise && res.push(obj.otherwise);
+            return res;
+          }, [])
+        );
+        property['x-alternatives'] = Hoek.clone(altArray);
+      }
+    } else {
+      property.anyOf = buildAlternativesArray(
+        joiObj.$_terms.matches.reduce((res, obj) => {
           obj.then && res.push(obj.then);
           obj.otherwise && res.push(obj.otherwise);
           return res;
         }, [])
-        .map((joiNewObj) => {
-          const childMetaName = Utilities.getJoiMetaProperty(joiNewObj, 'swaggerLabel');
-          const altName = childMetaName || Utilities.getJoiLabel(joiNewObj) || name;
-          return this.parseProperty(altName, joiNewObj, property, parameterType, useDefinitions, true);
-        })
-        .filter((obj) => obj);
-      property['x-alternatives'] = Hoek.clone(altArray);
+      );
+      delete property.type;
     }
   }
 
@@ -641,7 +666,15 @@ internals.properties.prototype.getDefinitionCollection = function (isAlt) {
  * @return {string}
  */
 internals.properties.prototype.getDefinitionRef = function (isAlt) {
-  return isAlt === true ? '#/x-alt-definitions/' : '#/definitions/';
+  if (isAlt === true) {
+    return '#/x-alt-definitions/';
+  }
+
+  if (this.settings.OAS === 'v2') {
+    return '#/definitions/';
+  }
+
+  return '#/components/schemas/';
 };
 
 /**

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -57,7 +57,7 @@ internals.responses.prototype.build = function (
     }
   }
 
-  // use plug-in options overrides to enchance hapi objects and properties
+  // use plug-in options overrides to enhance hapi objects and properties
   if (Utilities.hasProperties(userDefindedSchemas) === true) {
     out = this.optionOverride(out, userDefindedSchemas, useDefinitions, isAlt);
   }

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -7,19 +7,22 @@ const Utilities = require('../lib/utilities');
 
 const internals = {};
 
-exports = module.exports = internals.responses = function(
-  settings,
-  definitionCollection,
-  altDefinitionCollection,
-  definitionCache
-) {
-  this.settings = settings;
-  this.definitionCollection = definitionCollection;
-  this.altDefinitionCollection = altDefinitionCollection;
+exports =
+  module.exports =
+  internals.responses =
+    function (settings, definitionCollection, altDefinitionCollection, definitionCache) {
+      this.settings = settings;
+      this.definitionCollection = definitionCollection;
+      this.altDefinitionCollection = altDefinitionCollection;
 
-  this.definitions = new Definitions(settings);
-  this.properties = new Properties(settings, this.definitionCollection, this.altDefinitionCollection, definitionCache);
-};
+      this.definitions = new Definitions(settings);
+      this.properties = new Properties(
+        settings,
+        this.definitionCollection,
+        this.altDefinitionCollection,
+        definitionCache
+      );
+    };
 
 /**
  * build swagger response object
@@ -31,7 +34,7 @@ exports = module.exports = internals.responses = function(
  * @param  {Boolean} isAlt
  * @return {Object}
  */
-internals.responses.prototype.build = function(
+internals.responses.prototype.build = function (
   userDefindedSchemas,
   defaultSchema,
   statusSchemas,
@@ -88,7 +91,12 @@ internals.responses.prototype.build = function(
  * @param  {Boolean} isAlt
  * @return {Object}
  */
-internals.responses.prototype.optionOverride = function(discoveredSchemas, userDefindedSchemas, useDefinitions, isAlt) {
+internals.responses.prototype.optionOverride = function (
+  discoveredSchemas,
+  userDefindedSchemas,
+  useDefinitions,
+  isAlt
+) {
   for (const key in userDefindedSchemas) {
     // create a new object by cloning - dont modify user definded objects
     let out = Hoek.clone(userDefindedSchemas[key]);
@@ -135,10 +143,10 @@ internals.responses.prototype.optionOverride = function(discoveredSchemas, userD
  * @param  {Boolean} useDefinitions
  * @return {Object}
  */
-internals.responses.prototype.getResponse = function(statusCode, joiObj, useDefinitions) {
+internals.responses.prototype.getResponse = function (statusCode, joiObj, useDefinitions) {
   let out = {
     description: Hoek.reach(joiObj, '_flags.description'),
-    schema: this.properties.parseProperty(null, joiObj,null,'body', useDefinitions,false),
+    schema: this.properties.parseProperty(null, joiObj, null, 'body', useDefinitions, false),
     headers: Utilities.getJoiMetaProperty(joiObj, 'headers'),
     examples: Utilities.getJoiMetaProperty(joiObj, 'examples')
   };

--- a/lib/sort.js
+++ b/lib/sort.js
@@ -9,7 +9,7 @@ const sort = (module.exports = {});
  * @param  {Array} routes
  * @return {Array}
  */
-sort.paths = function(sortType, routes) {
+sort.paths = function (sortType, routes) {
   if (sortType === 'path-method') {
     //console.log('path-method')
     routes.sort(Utilities.firstBy('path').thenBy('method'));

--- a/lib/tags.js
+++ b/lib/tags.js
@@ -13,7 +13,7 @@ tags.schema = Joi.array().items(
     externalDocs: Joi.object({
       description: Joi.string(),
       url: Joi.string().uri()
-    }),
+    })
   })
     .label('Tag')
     .optional()
@@ -26,7 +26,7 @@ tags.schema = Joi.array().items(
  * @param  {Object} settings
  * @return {Object}
  */
-tags.build = function(settings) {
+tags.build = function (settings) {
   let out = [];
 
   if (settings.tags) {

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -9,7 +9,7 @@ const utilities = (module.exports = {});
  * @param  {Object} obj
  * @return {Boolean}
  */
-utilities.isObject = function(obj) {
+utilities.isObject = function (obj) {
   return obj !== null && obj !== undefined && typeof obj === 'object' && !Array.isArray(obj);
 };
 
@@ -19,17 +19,17 @@ utilities.isObject = function(obj) {
  * @param  {Object} obj
  * @return {Boolean}
  */
-(utilities.isFunction = function(obj) {
+(utilities.isFunction = function (obj) {
   // remove `obj.constructor` test as it was always true
   return !!(obj && obj.call && obj.apply);
-})
+})(
   /**
    * is passed item a regex
    *
    * @param  {Object} obj
    * @return {Boolean}
    */
-  (utilities.isRegex = function(obj) {
+  (utilities.isRegex = function (obj) {
     // base on https://github.com/ljharb/is-regex/
     // has a couple of edge use cases for different env  - hence coverage:off
     /* $lab:coverage:off$ */
@@ -53,7 +53,8 @@ utilities.isObject = function(obj) {
 
     return hasToStringTag ? tryRegexExec(obj) : toStr.call(obj) === regexClass;
     /* $lab:coverage:on$ */
-  });
+  })
+);
 
 /**
  * does an object have any of its own properties
@@ -61,7 +62,7 @@ utilities.isObject = function(obj) {
  * @param  {Object} obj
  * @return {Boolean}
  */
-utilities.hasProperties = function(obj) {
+utilities.hasProperties = function (obj) {
   for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       return true;
@@ -77,7 +78,7 @@ utilities.hasProperties = function(obj) {
  * @param  {Object} obj
  * @return {Object}
  */
-utilities.deleteEmptyProperties = function(obj) {
+utilities.deleteEmptyProperties = function (obj) {
   for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       // delete properties undefined values
@@ -113,7 +114,7 @@ utilities.deleteEmptyProperties = function(obj) {
  * @param  {Array} array
  * @return {Object}
  */
-utilities.first = function(array) {
+utilities.first = function (array) {
   return Array.isArray(array) ? array[0] : undefined;
 };
 
@@ -124,7 +125,7 @@ utilities.first = function(array) {
  * @param  {string} firstItem
  * @return {Array}
  */
-utilities.sortFirstItem = function(array, firstItem) {
+utilities.sortFirstItem = function (array, firstItem) {
   const input = Hoek.clone(array);
 
   if (!firstItem) {
@@ -133,7 +134,7 @@ utilities.sortFirstItem = function(array, firstItem) {
 
   const filteredInput = input.filter((item) => item !== firstItem);
 
-  return [ firstItem, ...filteredInput];
+  return [firstItem, ...filteredInput];
 };
 
 /**
@@ -144,7 +145,7 @@ utilities.sortFirstItem = function(array, firstItem) {
  * @param  {Object} replacement
  * @return {Array}
  */
-utilities.replaceValue = function(inputArray, current, replacement) {
+utilities.replaceValue = function (inputArray, current, replacement) {
   if (!inputArray || !current || !replacement) {
     return Hoek.clone(inputArray);
   }
@@ -166,7 +167,7 @@ utilities.replaceValue = function(inputArray, current, replacement) {
  * @param  {string} findKey
  * @return {Boolean}
  */
-utilities.hasKey = function(obj, findKey) {
+utilities.hasKey = function (obj, findKey) {
   for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       if (typeof obj[key] === 'object') {
@@ -192,7 +193,7 @@ utilities.hasKey = function(obj, findKey) {
  * @param  {string} replaceKey
  * @return {Object}
  */
-utilities.findAndRenameKey = function(obj, findKey, replaceKey) {
+utilities.findAndRenameKey = function (obj, findKey, replaceKey) {
   for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       if (typeof obj[key] === 'object') {
@@ -220,7 +221,7 @@ utilities.findAndRenameKey = function(obj, findKey, replaceKey) {
 
 	* @return {Object}
 	*/
-utilities.removeProps = function(obj, listOfProps) {
+utilities.removeProps = function (obj, listOfProps) {
   for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       if (listOfProps.indexOf(key) === -1 && key.startsWith('x-') === false) {
@@ -238,8 +239,8 @@ utilities.removeProps = function(obj, listOfProps) {
  * @param  {Object} joiObj
  * @return {Boolean}
  */
-utilities.isJoi = function(joiObj) {
-  return joiObj && Joi.isSchema(joiObj)
+utilities.isJoi = function (joiObj) {
+  return joiObj && Joi.isSchema(joiObj);
 };
 
 /**
@@ -248,13 +249,13 @@ utilities.isJoi = function(joiObj) {
  * @param  {Object} joiObj
  * @return {Boolean}
  */
-utilities.hasJoiChildren = function(joiObj) {
-  if (!(utilities.isJoi(joiObj))) {
+utilities.hasJoiChildren = function (joiObj) {
+  if (!utilities.isJoi(joiObj)) {
     return false;
   }
 
-  const byId = Hoek.reach(joiObj, '_ids._byId')
-  const byKey = Hoek.reach(joiObj, '_ids._byKey')
+  const byId = Hoek.reach(joiObj, '_ids._byId');
+  const byKey = Hoek.reach(joiObj, '_ids._byKey');
 
   // TODO add tests to cover "byId.size > 0"
   return byKey.size > 0 || byId.size > 0;
@@ -266,7 +267,7 @@ utilities.hasJoiChildren = function(joiObj) {
  * @param  {Object} joiObj
  * @return {Boolean}
  */
-utilities.hasJoiDescription = function(joiObj) {
+utilities.hasJoiDescription = function (joiObj) {
   if (!utilities.isJoi(joiObj)) {
     return false;
   }
@@ -280,7 +281,7 @@ utilities.hasJoiDescription = function(joiObj) {
  * @param  {Object} joiObj
  * @return {Boolean}
  */
-utilities.hasJoiMeta = function(joiObj) {
+utilities.hasJoiMeta = function (joiObj) {
   return utilities.isJoi(joiObj) && joiObj.$_terms.metas.length > 0;
 };
 
@@ -291,7 +292,7 @@ utilities.hasJoiMeta = function(joiObj) {
  * @param  {string} propertyName
  * @return {Object || Undefined}
  */
-utilities.getJoiMetaProperty = function(joiObj, propertyName) {
+utilities.getJoiMetaProperty = function (joiObj, propertyName) {
   // get headers added using meta function
   if (utilities.isJoi(joiObj) && utilities.hasJoiMeta(joiObj)) {
     const meta = joiObj.$_terms.metas;
@@ -312,7 +313,7 @@ utilities.getJoiMetaProperty = function(joiObj, propertyName) {
  * @param  {Object} joiObj
  * @return {String || Null}
  */
-utilities.getJoiLabel = function(joiObj) {
+utilities.getJoiLabel = function (joiObj) {
   // old version
   /* $lab:coverage:off$ */
   const label = Hoek.reach(joiObj, '_settings.language.label');
@@ -333,7 +334,7 @@ utilities.getJoiLabel = function(joiObj) {
  * @param  {Object} obj
  * @return {Object}
  */
-utilities.toJoiObject = function(obj) {
+utilities.toJoiObject = function (obj) {
   if (!utilities.isJoi(obj) && utilities.isObject(obj)) {
     return Joi.object(obj);
   }
@@ -346,15 +347,15 @@ utilities.toJoiObject = function(obj) {
  *
  * @return {Function}
  */
-utilities.firstBy = (function() {
+utilities.firstBy = (function () {
   // code from https://github.com/Teun/thenBy.js
   // has its own tests
   /* $lab:coverage:off$ */
-  const makeCompareFunction = function(f, direction) {
+  const makeCompareFunction = function (f, direction) {
     if (typeof f !== 'function') {
       const prop = f;
       // make unary function
-      f = function(v1) {
+      f = function (v1) {
         return v1[prop];
       };
     }
@@ -362,13 +363,13 @@ utilities.firstBy = (function() {
     if (f.length === 1) {
       // f is a unary function mapping a single item to its sort score
       const uf = f;
-      f = function(v1, v2) {
+      f = function (v1, v2) {
         return uf(v1) < uf(v2) ? -1 : uf(v1) > uf(v2) ? 1 : 0;
       };
     }
 
     if (direction === -1) {
-      return function(v1, v2) {
+      return function (v1, v2) {
         return -f(v1, v2);
       };
     }
@@ -377,7 +378,7 @@ utilities.firstBy = (function() {
   };
 
   /* mixin for the `thenBy` property */
-  const extend = function(f, d) {
+  const extend = function (f, d) {
     f = makeCompareFunction(f, d);
     f.thenBy = tb;
     return f;
@@ -386,7 +387,7 @@ utilities.firstBy = (function() {
   /* adds a secondary compare function to the target function (`this` context)
        which is applied in case the first one returns 0 (equal)
        returns a new compare function, which has a `thenBy` method as well */
-  const tb = function(y, d) {
+  const tb = function (y, d) {
     const self = this;
     y = makeCompareFunction(y, d);
     return extend((a, b) => {
@@ -405,7 +406,7 @@ utilities.firstBy = (function() {
  * @param  {string} path
  * @return {string}
  */
-utilities.createId = function(method, path) {
+utilities.createId = function (method, path) {
   const self = this;
 
   if (!path.includes('/')) {
@@ -430,7 +431,7 @@ utilities.createId = function(method, path) {
  * @param  {string} word
  * @return {string}
  */
-utilities.toTitleCase = function(word) {
+utilities.toTitleCase = function (word) {
   return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
 };
 
@@ -442,8 +443,8 @@ utilities.toTitleCase = function(word) {
  * @param  {Array} options
  * @return {string}
  */
-utilities.replaceInPath = function(path, applyTo, options) {
-  options.forEach(option => {
+utilities.replaceInPath = function (path, applyTo, options) {
+  options.forEach((option) => {
     if (applyTo.includes(option.replaceIn) || option.replaceIn === 'all') {
       path = path.replace(option.pattern, option.replacement);
     }
@@ -457,7 +458,7 @@ utilities.replaceInPath = function(path, applyTo, options) {
  * @param  {string} str
  * @return {string}
  */
-utilities.removeTrailingSlash = function(str) {
+utilities.removeTrailingSlash = function (str) {
   return str.endsWith('/') ? str.slice(0, -1) : str;
 };
 
@@ -468,7 +469,7 @@ utilities.removeTrailingSlash = function(str) {
  * @param  {Object} source
  * @return {Object}
  */
-utilities.assignVendorExtensions = function(target, source) {
+utilities.assignVendorExtensions = function (target, source) {
   if (!this.isObject(target) || !this.isObject(source)) {
     return target;
   }
@@ -496,7 +497,7 @@ utilities.appendQueryString = function (inputUrl, qsName, qsValue) {
     return inputUrl;
   }
 
-  const [ url, queryString ] = inputUrl.split('?');
+  const [url, queryString] = inputUrl.split('?');
   const searchParams = new URLSearchParams(queryString);
 
   searchParams.set(qsName, qsValue);

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -19,42 +19,42 @@ utilities.isObject = function (obj) {
  * @param  {Object} obj
  * @return {Boolean}
  */
-(utilities.isFunction = function (obj) {
+utilities.isFunction = function (obj) {
   // remove `obj.constructor` test as it was always true
   return !!(obj && obj.call && obj.apply);
-})(
-  /**
-   * is passed item a regex
-   *
-   * @param  {Object} obj
-   * @return {Boolean}
-   */
-  (utilities.isRegex = function (obj) {
-    // base on https://github.com/ljharb/is-regex/
-    // has a couple of edge use cases for different env  - hence coverage:off
-    /* $lab:coverage:off$ */
-    const regexExec = RegExp.prototype.exec;
-    const tryRegexExec = function tryRegexExec(value) {
-      try {
-        regexExec.call(value);
-        return true;
-      } catch (e) {
-        return false;
-      }
-    };
+};
 
-    const toStr = Object.prototype.toString;
-    const regexClass = '[object RegExp]';
-    const hasToStringTag = typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol';
-
-    if (typeof obj !== 'object') {
+/**
+ * is passed item a regex
+ *
+ * @param  {Object} obj
+ * @return {Boolean}
+ */
+utilities.isRegex = function (obj) {
+  // base on https://github.com/ljharb/is-regex/
+  // has a couple of edge use cases for different env  - hence coverage:off
+  /* $lab:coverage:off$ */
+  const regexExec = RegExp.prototype.exec;
+  const tryRegexExec = function tryRegexExec(value) {
+    try {
+      regexExec.call(value);
+      return true;
+    } catch (e) {
       return false;
     }
+  };
 
-    return hasToStringTag ? tryRegexExec(obj) : toStr.call(obj) === regexClass;
-    /* $lab:coverage:on$ */
-  })
-);
+  const toStr = Object.prototype.toString;
+  const regexClass = '[object RegExp]';
+  const hasToStringTag = typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol';
+
+  if (typeof obj !== 'object') {
+    return false;
+  }
+
+  return hasToStringTag ? tryRegexExec(obj) : toStr.call(obj) === regexClass;
+  /* $lab:coverage:on$ */
+};
 
 /**
  * does an object have any of its own properties

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -27,7 +27,7 @@ validate.log = async (doc, logFnc) => {
  * @param  {Object} doc
  * @return {boolean}
  */
-validate.test = async doc => {
+validate.test = async (doc) => {
   try {
     await SwaggerParser.validate(doc);
     return true;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "scripts": {
     "start": "node examples/simple.js",
+    "start:openapi": "node examples/simple-openapi.js",
     "start:basic": "node examples/basic.js",
     "start:debug": "node examples/debug.js",
     "start:jwt": "node examples/jwt.js",

--- a/test/Integration/builder-openapi-test.js
+++ b/test/Integration/builder-openapi-test.js
@@ -1,0 +1,391 @@
+const Joi = require('joi');
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+const Helper = require('../helper.js');
+const Validate = require('../../lib/validate.js');
+
+const expect = Code.expect;
+const lab = (exports.lab = Lab.script());
+
+const routes = [
+  {
+    method: 'GET',
+    path: '/test',
+    handler: Helper.defaultHandler,
+    options: {
+      tags: ['api']
+    }
+  },
+  {
+    method: 'GET',
+    path: '/test2',
+    handler: Helper.defaultHandler,
+    options: {
+      tags: ['api2']
+    }
+  },
+  {
+    method: 'GET',
+    path: '/not-part-of-api',
+    handler: Helper.defaultHandler,
+    options: {
+      tags: ['other']
+    }
+  }
+];
+
+const xPropertiesRoutes = [
+  {
+    method: 'POST',
+    path: '/test',
+    handler: Helper.defaultHandler,
+    options: {
+      tags: ['api'],
+      validate: {
+        payload: Joi.object({
+          number: Joi.number().greater(10),
+          string: Joi.string().alphanum(),
+          array: Joi.array().items(Joi.string()).length(2)
+        })
+      }
+    }
+  }
+];
+
+const reuseModelsRoutes = [
+  {
+    method: 'POST',
+    path: '/test',
+    handler: Helper.defaultHandler,
+    options: {
+      tags: ['api'],
+      validate: {
+        payload: Joi.object({
+          a: Joi.object({ a: Joi.string() }),
+          b: Joi.object({ a: Joi.string() })
+        })
+      }
+    }
+  }
+];
+
+lab.experiment('builder', () => {
+  lab.test('defaults for swagger root object properties', async () => {
+    const server = await Helper.createServer({}, routes);
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+
+    expect(response.statusCode).to.equal(200);
+    expect(response.result.swagger).to.equal('2.0');
+    expect(response.result.schemes).to.equal(['http']);
+    expect(response.result.basePath).to.equal('/');
+    expect(response.result.consumes).to.not.exist();
+    expect(response.result.produces).to.not.exist();
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('set values for swagger root object properties', async () => {
+    const swaggerOptions = {
+      swagger: '5.9.45',
+      schemes: ['https'],
+      basePath: '/base',
+      consumes: ['application/x-www-form-urlencoded'],
+      produces: ['application/json', 'application/xml'],
+      externalDocs: {
+        description: 'Find out more about Hapi',
+        url: 'http://hapijs.com'
+      },
+      'x-custom': 'custom'
+    };
+
+    const server = await Helper.createServer(swaggerOptions, routes);
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+
+    expect(response.statusCode).to.equal(200);
+    expect(response.result.swagger).to.equal('2.0');
+    expect(response.result.schemes).to.equal(['https']);
+    expect(response.result.basePath).to.equal('/base');
+    expect(response.result.consumes).to.equal(['application/x-www-form-urlencoded']);
+    expect(response.result.produces).to.equal(['application/json', 'application/xml']);
+    expect(response.result.externalDocs).to.equal(swaggerOptions.externalDocs);
+    expect(response.result['x-custom']).to.equal('custom');
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('xProperties : false', async () => {
+    const server = await Helper.createServer({ xProperties: false }, xPropertiesRoutes);
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+
+    expect(response.result.definitions).to.equal({
+      array: {
+        type: 'array',
+        items: {
+          type: 'string'
+        }
+      },
+      Model1: {
+        type: 'object',
+        properties: {
+          number: {
+            type: 'number'
+          },
+          string: {
+            type: 'string'
+          },
+          array: {
+            $ref: '#/definitions/array'
+          }
+        }
+      }
+    });
+
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('xProperties : true', async () => {
+    const server = await Helper.createServer({ xProperties: true }, xPropertiesRoutes);
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+
+    expect(response.result.definitions).to.equal({
+      array: {
+        type: 'array',
+        'x-constraint': {
+          length: 2
+        },
+        items: {
+          type: 'string'
+        }
+      },
+      Model1: {
+        type: 'object',
+        properties: {
+          number: {
+            type: 'number',
+            'x-constraint': {
+              greater: 10
+            }
+          },
+          string: {
+            type: 'string',
+            'x-format': {
+              alphanum: true
+            }
+          },
+          array: {
+            $ref: '#/definitions/array'
+          }
+        }
+      }
+    });
+
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test(
+    'reuseDefinitions : true. It should not be reused, because of the exact definition, but a different label.',
+    async () => {
+      const server = await Helper.createServer({ reuseDefinitions: true }, reuseModelsRoutes);
+      const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+
+      expect(response.result.definitions).to.equal({
+        a: {
+          type: 'object',
+          properties: {
+            a: {
+              type: 'string'
+            }
+          }
+        },
+        b: {
+          type: 'object',
+          properties: {
+            a: {
+              type: 'string'
+            }
+          }
+        },
+        Model1: {
+          type: 'object',
+          properties: {
+            a: {
+              $ref: '#/definitions/a'
+            },
+            b: {
+              $ref: '#/definitions/b'
+            }
+          }
+        }
+      });
+
+      const isValid = await Validate.test(response.result);
+      expect(isValid).to.be.true();
+    }
+  );
+
+  lab.test('reuseDefinitions : false', async () => {
+    const server = await Helper.createServer({ reuseDefinitions: false }, reuseModelsRoutes);
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+
+    //console.log(JSON.stringify(response.result));
+    expect(response.result.definitions).to.equal({
+      a: {
+        type: 'object',
+        properties: {
+          a: {
+            type: 'string'
+          }
+        }
+      },
+      b: {
+        type: 'object',
+        properties: {
+          a: {
+            type: 'string'
+          }
+        }
+      },
+      Model1: {
+        type: 'object',
+        properties: {
+          a: {
+            $ref: '#/definitions/a'
+          },
+          b: {
+            $ref: '#/definitions/b'
+          }
+        }
+      }
+    });
+
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('getSwaggerJSON determines host and port from request info', async () => {
+    const server = await Helper.createServer({});
+
+    const response = await server.inject({
+      method: 'GET',
+      headers: { host: '194.148.15.24:7645' },
+      url: '/swagger.json'
+    });
+
+    expect(response.statusCode).to.equal(200);
+    expect(response.result.host).to.equal('194.148.15.24:7645');
+  });
+
+  lab.test("getSwaggerJSON doesn't specify port from request info when port is default", async () => {
+    const server = await Helper.createServer({});
+
+    const response = await server.inject({
+      method: 'GET',
+      headers: { host: '194.148.15.24' },
+      url: '/swagger.json'
+    });
+
+    expect(response.statusCode).to.equal(200);
+    expect(response.result.host).to.equal('194.148.15.24');
+  });
+
+  lab.test('routeTag : "api"', async () => {
+    const server = await Helper.createServer({ routeTag: 'api' }, routes);
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+
+    expect(response.result.paths['/test']).to.equal({
+      get: {
+        operationId: 'getTest',
+        responses: {
+          default: {
+            description: 'Successful',
+            schema: {
+              type: 'string'
+            }
+          }
+        },
+        tags: ['test']
+      }
+    });
+    expect(response.result.paths['/test2']).to.equal(undefined);
+    expect(response.result.paths['/not-part-of-api']).to.equal(undefined);
+
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('routeTag : "api2"', async () => {
+    const server = await Helper.createServer({ routeTag: 'api2' }, routes);
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+
+    expect(response.result.paths['/test']).to.equal(undefined);
+    expect(response.result.paths['/test2']).to.equal({
+      get: {
+        operationId: 'getTest2',
+        responses: {
+          default: {
+            description: 'Successful',
+            schema: {
+              type: 'string'
+            }
+          }
+        },
+        tags: ['test2']
+      }
+    });
+    expect(response.result.paths['/not-part-of-api']).to.equal(undefined);
+
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+});
+
+lab.experiment('builder', () => {
+  let logs = [];
+  lab.before(async () => {
+    const server = await Helper.createServer({ debug: true }, reuseModelsRoutes);
+
+    return new Promise((resolve) => {
+      server.events.on('log', (event) => {
+        logs = event.tags;
+        //console.log(event);
+        if (event.data === 'PASSED - The swagger.json validation passed.') {
+          logs = event.tags;
+          resolve();
+        }
+      });
+      server.inject({ method: 'GET', url: '/swagger.json' });
+    });
+  });
+
+  lab.test('debug : true', () => {
+    expect(logs).to.equal(['hapi-swagger', 'validation', 'info']);
+  });
+});
+
+lab.experiment('fix issue 711', () => {
+  lab.test('The description field is shown when an object is empty', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/todo/{id}/',
+      options: {
+        handler: () => {},
+        description: 'Test',
+        notes: 'Test notes',
+        tags: ['api'],
+        validate: {
+          payload: Joi.object().description('MyDescription').label('MySchema')
+        }
+      }
+    };
+
+    const server = await Helper.createServer({ debug: true }, routes);
+    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+    expect(response.statusCode).to.equal(200);
+
+    const { MySchema } = response.result.definitions;
+    expect(MySchema).not.to.equal({ type: 'object' });
+    expect(MySchema).to.equal({ type: 'object', description: 'MyDescription' });
+  });
+});

--- a/test/Integration/builder-test.js
+++ b/test/Integration/builder-test.js
@@ -45,9 +45,7 @@ const xPropertiesRoutes = [
         payload: Joi.object({
           number: Joi.number().greater(10),
           string: Joi.string().alphanum(),
-          array: Joi.array()
-            .items(Joi.string())
-            .length(2)
+          array: Joi.array().items(Joi.string()).length(2)
         })
       }
     }
@@ -126,7 +124,7 @@ lab.experiment('builder', () => {
           type: 'string'
         }
       },
-      'Model1': {
+      Model1: {
         type: 'object',
         properties: {
           number: {
@@ -146,7 +144,7 @@ lab.experiment('builder', () => {
     expect(isValid).to.be.true();
   });
 
-  lab.test('xProperties : false', async () => {
+  lab.test('xProperties : true', async () => {
     const server = await Helper.createServer({ xProperties: true }, xPropertiesRoutes);
     const response = await server.inject({ method: 'GET', url: '/swagger.json' });
 
@@ -160,7 +158,7 @@ lab.experiment('builder', () => {
           type: 'string'
         }
       },
-      'Model1': {
+      Model1: {
         type: 'object',
         properties: {
           number: {
@@ -186,43 +184,46 @@ lab.experiment('builder', () => {
     expect(isValid).to.be.true();
   });
 
-  lab.test('reuseDefinitions : true. It should not be reused, because of the exact definition, but a different label.', async () => {
-    const server = await Helper.createServer({ reuseDefinitions: true }, reuseModelsRoutes);
-    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+  lab.test(
+    'reuseDefinitions : true. It should not be reused, because of the exact definition, but a different label.',
+    async () => {
+      const server = await Helper.createServer({ reuseDefinitions: true }, reuseModelsRoutes);
+      const response = await server.inject({ method: 'GET', url: '/swagger.json' });
 
-    expect(response.result.definitions).to.equal({
-      a: {
-        type: 'object',
-        properties: {
-          a: {
-            type: 'string'
+      expect(response.result.definitions).to.equal({
+        a: {
+          type: 'object',
+          properties: {
+            a: {
+              type: 'string'
+            }
+          }
+        },
+        b: {
+          type: 'object',
+          properties: {
+            a: {
+              type: 'string'
+            }
+          }
+        },
+        Model1: {
+          type: 'object',
+          properties: {
+            a: {
+              $ref: '#/definitions/a'
+            },
+            b: {
+              $ref: '#/definitions/b'
+            }
           }
         }
-      },
-      b: {
-        type: 'object',
-        properties: {
-          a: {
-            type: 'string'
-          }
-        }
-      },
-      'Model1': {
-        type: 'object',
-        properties: {
-          a: {
-            $ref: '#/definitions/a'
-          },
-          b: {
-            $ref: '#/definitions/b'
-          }
-        }
-      }
-    });
+      });
 
-    const isValid = await Validate.test(response.result);
-    expect(isValid).to.be.true();
-  });
+      const isValid = await Validate.test(response.result);
+      expect(isValid).to.be.true();
+    }
+  );
 
   lab.test('reuseDefinitions : false', async () => {
     const server = await Helper.createServer({ reuseDefinitions: false }, reuseModelsRoutes);
@@ -246,7 +247,7 @@ lab.experiment('builder', () => {
           }
         }
       },
-      'Model1': {
+      Model1: {
         type: 'object',
         properties: {
           a: {
@@ -295,21 +296,18 @@ lab.experiment('builder', () => {
 
     expect(response.result.paths['/test']).to.equal({
       get: {
-          operationId: 'getTest',
-          responses: {
-            default: {
-              description: 'Successful',
-              schema: {
-                type: 'string'
-              }
+        operationId: 'getTest',
+        responses: {
+          default: {
+            description: 'Successful',
+            schema: {
+              type: 'string'
             }
-          },
-          tags: [
-            'test'
-          ]
-        }
+          }
+        },
+        tags: ['test']
       }
-    );
+    });
     expect(response.result.paths['/test2']).to.equal(undefined);
     expect(response.result.paths['/not-part-of-api']).to.equal(undefined);
 
@@ -324,21 +322,18 @@ lab.experiment('builder', () => {
     expect(response.result.paths['/test']).to.equal(undefined);
     expect(response.result.paths['/test2']).to.equal({
       get: {
-          operationId: 'getTest2',
-          responses: {
-            default: {
-              description: 'Successful',
-              schema: {
-                type: 'string'
-              }
+        operationId: 'getTest2',
+        responses: {
+          default: {
+            description: 'Successful',
+            schema: {
+              type: 'string'
             }
-          },
-          tags: [
-            'test2'
-          ]
-        }
+          }
+        },
+        tags: ['test2']
       }
-    );
+    });
     expect(response.result.paths['/not-part-of-api']).to.equal(undefined);
 
     const isValid = await Validate.test(response.result);
@@ -351,8 +346,8 @@ lab.experiment('builder', () => {
   lab.before(async () => {
     const server = await Helper.createServer({ debug: true }, reuseModelsRoutes);
 
-    return new Promise(resolve => {
-      server.events.on('log', event => {
+    return new Promise((resolve) => {
+      server.events.on('log', (event) => {
         logs = event.tags;
         //console.log(event);
         if (event.data === 'PASSED - The swagger.json validation passed.') {
@@ -369,23 +364,20 @@ lab.experiment('builder', () => {
   });
 });
 
-
 lab.experiment('fix issue 711', () => {
   lab.test('The description field is shown when an object is empty', async () => {
     const routes = {
-        method: 'POST',
-        path: '/todo/{id}/',
-        options: {
-            handler: () => {},
-            description: 'Test',
-            notes: 'Test notes',
-            tags: ['api'],
-            validate: {
-                payload: Joi.object()
-                    .description('MyDescription')
-                    .label('MySchema')
-            }
-        },
+      method: 'POST',
+      path: '/todo/{id}/',
+      options: {
+        handler: () => {},
+        description: 'Test',
+        notes: 'Test notes',
+        tags: ['api'],
+        validate: {
+          payload: Joi.object().description('MyDescription').label('MySchema')
+        }
+      }
     };
 
     const server = await Helper.createServer({ debug: true }, routes);
@@ -393,7 +385,7 @@ lab.experiment('fix issue 711', () => {
     expect(response.statusCode).to.equal(200);
 
     const { MySchema } = response.result.definitions;
-    expect(MySchema).not.to.equal({ type: 'object'})
-    expect(MySchema).to.equal({ type: 'object', description: 'MyDescription' })
-});
+    expect(MySchema).not.to.equal({ type: 'object' });
+    expect(MySchema).to.equal({ type: 'object', description: 'MyDescription' });
+  });
 });

--- a/test/Integration/child-model-openapi.js
+++ b/test/Integration/child-model-openapi.js
@@ -9,10 +9,10 @@ const Validate = require('../../lib/validate.js');
 const expect = Code.expect;
 const lab = (exports.lab = Lab.script());
 
-lab.experiment('child-models', () => {
+lab.experiment('child-models (OpenAPI)', () => {
   const requestOptions = {
     method: 'GET',
-    url: '/swagger.json',
+    url: '/openapi.json',
     headers: {
       host: 'localhost'
     }
@@ -97,28 +97,34 @@ lab.experiment('child-models', () => {
   ];
 
   lab.test('child definitions models', async () => {
-    const server = await Helper.createServer({}, routes);
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
     const response = await server.inject(requestOptions);
 
     expect(response.statusCode).to.equal(200);
 
-    expect(response.result.paths['/foo/v1/bar'].post.parameters[0].schema).to.equal({
-      $ref: '#/definitions/Model1'
+    expect(response.result.paths['/foo/v1/bar'].post.requestBody).to.equal({
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Model1'
+          }
+        }
+      }
     });
 
-    expect(response.result.definitions.Model1).to.equal({
+    expect(response.result.components.schemas.Model1).to.equal({
       properties: {
         outer1: {
-          $ref: '#/definitions/outer1'
+          $ref: '#/components/schemas/outer1'
         },
         outer2: {
-          $ref: '#/definitions/outer2'
+          $ref: '#/components/schemas/outer2'
         }
       },
       type: 'object'
     });
 
-    expect(response.result.definitions.outer1).to.equal({
+    expect(response.result.components.schemas.outer1).to.equal({
       properties: {
         inner1: {
           type: 'string'
@@ -131,26 +137,39 @@ lab.experiment('child-models', () => {
   });
 
   lab.test('object within an object - array within an array', async () => {
-    const server = await Helper.createServer({}, routes);
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
     const response = await server.inject(requestOptions);
 
     expect(response.statusCode).to.equal(200);
 
-    expect(response.result.paths['/bar/objects'].post.parameters[0].schema).to.equal({
-      $ref: '#/definitions/FooObjParent'
-    });
-    expect(response.result.paths['/bar/objects'].post.responses[200].schema).to.equal({
-      $ref: '#/definitions/FooObjParent'
-    });
-    expect(response.result.definitions.FooObjParent).to.equal({
-      type: 'object',
-      properties: {
-        foos: {
-          $ref: '#/definitions/FooObj'
+    expect(response.result.paths['/bar/objects'].post.requestBody).to.equal({
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/FooObjParent'
+          }
         }
       }
     });
-    expect(response.result.definitions.FooObj).to.equal({
+    expect(response.result.paths['/bar/objects'].post.responses[200]).to.equal({
+      description: 'Successful',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/FooObjParent'
+          }
+        }
+      }
+    });
+    expect(response.result.components.schemas.FooObjParent).to.equal({
+      type: 'object',
+      properties: {
+        foos: {
+          $ref: '#/components/schemas/FooObj'
+        }
+      }
+    });
+    expect(response.result.components.schemas.FooObj).to.equal({
       type: 'object',
       properties: {
         foo: {
@@ -160,25 +179,38 @@ lab.experiment('child-models', () => {
       }
     });
 
-    expect(response.result.paths['/bar/arrays'].post.parameters[0].schema).to.equal({
-      $ref: '#/definitions/FooArrParent'
-    });
-    expect(response.result.paths['/bar/arrays'].post.responses[200].schema).to.equal({
-      $ref: '#/definitions/FooArrParent'
-    });
-    expect(response.result.definitions.FooArrParent).to.equal({
-      type: 'array',
-      items: {
-        $ref: '#/definitions/FooArr'
+    expect(response.result.paths['/bar/arrays'].post.requestBody).to.equal({
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/FooArrParent'
+          }
+        }
       }
     });
-    expect(response.result.definitions.FooArr).to.equal({
-      type: 'array',
-      items: {
-        $ref: '#/definitions/FooArrObj'
+    expect(response.result.paths['/bar/arrays'].post.responses[200]).to.equal({
+      description: 'Successful',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/FooArrParent'
+          }
+        }
       }
     });
-    expect(response.result.definitions.FooArrObj).to.equal({
+    expect(response.result.components.schemas.FooArrParent).to.equal({
+      type: 'array',
+      items: {
+        $ref: '#/components/schemas/FooArr'
+      }
+    });
+    expect(response.result.components.schemas.FooArr).to.equal({
+      type: 'array',
+      items: {
+        $ref: '#/components/schemas/FooArrObj'
+      }
+    });
+    expect(response.result.components.schemas.FooArrObj).to.equal({
       type: 'object',
       properties: {
         bar: {

--- a/test/Integration/definitions-openapi-test.js
+++ b/test/Integration/definitions-openapi-test.js
@@ -1,0 +1,414 @@
+const Code = require('@hapi/code');
+const Joi = require('joi');
+const Lab = require('@hapi/lab');
+const Helper = require('../helper.js');
+const Validate = require('../../lib/validate.js');
+
+const expect = Code.expect;
+const lab = (exports.lab = Lab.script());
+
+lab.experiment('definitions (OpenAPI)', () => {
+  const routes = [
+    {
+      method: 'POST',
+      path: '/test/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        validate: {
+          payload: Joi.object({
+            a: Joi.number().required().description('the first number'),
+
+            b: Joi.number().required().description('the second number'),
+
+            operator: Joi.string().required().default('+').description('the operator i.e. + - / or *'),
+
+            equals: Joi.number().required().description('the result of the sum')
+          })
+        }
+      }
+    },
+    {
+      method: 'POST',
+      path: '/test/2',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        validate: {
+          payload: Joi.object({
+            a: Joi.string(),
+            b: Joi.object({
+              c: Joi.string()
+            })
+          }).label('Model')
+        }
+      }
+    },
+    {
+      method: 'POST',
+      path: '/test/3',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        validate: {
+          payload: Joi.object({
+            a: Joi.string(),
+            b: Joi.object({
+              c: Joi.string()
+            })
+          }).label('Model1')
+        }
+      }
+    }
+  ];
+
+  lab.test('payload with inline definition', async () => {
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+
+    const definition = {
+      properties: {
+        a: {
+          description: 'the first number',
+          type: 'number'
+        },
+        b: {
+          description: 'the second number',
+          type: 'number'
+        },
+        operator: {
+          description: 'the operator i.e. + - / or *',
+          default: '+',
+          type: 'string'
+        },
+        equals: {
+          description: 'the result of the sum',
+          type: 'number'
+        }
+      },
+      required: ['a', 'b', 'operator', 'equals'],
+      type: 'object'
+    };
+
+    const response = await server.inject({ method: 'GET', url: '/openapi.json' });
+
+    expect(response.statusCode).to.equal(200);
+    expect(response.result.paths['/test/'].post.requestBody).to.equal({
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Model2'
+          }
+        }
+      }
+    });
+    expect(response.result.components.schemas.Model2).to.equal(definition);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('override definition named Model', async () => {
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ method: 'GET', url: '/openapi.json' });
+
+    //console.log(JSON.stringify(response.result.definitions));
+    expect(response.result.components.schemas.b).to.exists();
+    expect(response.result.components.schemas.Model).to.exists();
+    expect(response.result.components.schemas.Model1).to.exists();
+
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('reuseDefinitions = false', async () => {
+    // forces two models even though the model hash is the same
+
+    const tempRoutes = [
+      {
+        method: 'POST',
+        path: '/store1/',
+        options: {
+          handler: Helper.defaultHandler,
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              a: Joi.number(),
+              b: Joi.number(),
+              operator: Joi.string(),
+              equals: Joi.number()
+            }).label('A')
+          }
+        }
+      },
+      {
+        method: 'POST',
+        path: '/store2/',
+        options: {
+          handler: Helper.defaultHandler,
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              a: Joi.number(),
+              b: Joi.number(),
+              operator: Joi.string(),
+              equals: Joi.number()
+            }).label('B')
+          }
+        }
+      }
+    ];
+
+    const server = await Helper.createServer({ OAS: 'v3.0', reuseDefinitions: false }, tempRoutes);
+
+    const response = await server.inject({ method: 'GET', url: '/openapi.json' });
+
+    //console.log(JSON.stringify(response.result));
+    expect(response.statusCode).to.equal(200);
+    expect(response.result.components.schemas.A).to.exist();
+    expect(response.result.components.schemas.B).to.exist();
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('definitionPrefix = useLabel', async () => {
+    // use the label as a prefix for dynamic model names
+
+    const tempRoutes = [
+      {
+        method: 'POST',
+        path: '/store1/',
+        options: {
+          handler: Helper.defaultHandler,
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              a: Joi.number(),
+              b: Joi.number(),
+              operator: Joi.string(),
+              equals: Joi.number()
+            }).label('A')
+          }
+        }
+      },
+      {
+        method: 'POST',
+        path: '/store2/',
+        options: {
+          handler: Helper.defaultHandler,
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              c: Joi.number(),
+              v: Joi.number(),
+              operator: Joi.string(),
+              equals: Joi.number()
+            }).label('A A')
+          }
+        }
+      },
+      {
+        method: 'POST',
+        path: '/store3/',
+        options: {
+          handler: Helper.defaultHandler,
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              c: Joi.number(),
+              f: Joi.number(),
+              operator: Joi.string(),
+              equals: Joi.number()
+            }).label('A')
+          }
+        }
+      }
+    ];
+
+    const server = await Helper.createServer({ OAS: 'v3.0', definitionPrefix: 'useLabel' }, tempRoutes);
+
+    const response = await server.inject({ method: 'GET', url: '/openapi.json' });
+
+    expect(response.statusCode).to.equal(200);
+    expect(response.result.components.schemas.A).to.exist();
+    expect(response.result.components.schemas['A A']).to.exist();
+    expect(response.result.components.schemas.A1).to.exist();
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('test that optional array is not in swagger output', async () => {
+    const testRoutes = [
+      {
+        method: 'POST',
+        path: '/server/1/',
+        options: {
+          handler: Helper.defaultHandler,
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              a: Joi.number().required(),
+              b: Joi.string().optional()
+            }).label('test')
+          }
+        }
+      }
+    ];
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, testRoutes);
+
+    const response = await server.inject({ method: 'GET', url: '/openapi.json' });
+
+    expect(response.statusCode).to.equal(200);
+    expect(response.result.components.schemas.test).to.equal({
+      type: 'object',
+      properties: {
+        a: {
+          type: 'number'
+        },
+        b: {
+          type: 'string'
+        }
+      },
+      required: ['a']
+    });
+  });
+
+  lab.test('test that name changing for required', async () => {
+    const FormDependencyDefinition = Joi.object({
+      id: Joi.number().required()
+    }).label('FormDependencyDefinition');
+
+    const ActionDefinition = Joi.object({
+      id: Joi.number().required().allow(null),
+      reminder: FormDependencyDefinition.required()
+    }).label('ActionDefinition');
+
+    const testRoutes = [
+      {
+        method: 'POST',
+        path: '/server/',
+        options: {
+          handler: Helper.defaultHandler,
+          tags: ['api'],
+          validate: {
+            payload: ActionDefinition
+          }
+        }
+      }
+    ];
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, testRoutes);
+
+    const response = await server.inject({ method: 'GET', url: '/openapi.json' });
+
+    expect(response.statusCode).to.equal(200);
+    expect(response.result.components.schemas.ActionDefinition).to.equal({
+      type: 'object',
+      properties: {
+        id: {
+          type: 'number',
+          nullable: true
+        },
+        reminder: {
+          $ref: '#/components/schemas/FormDependencyDefinition'
+        }
+      },
+      required: ['id', 'reminder']
+    });
+  });
+
+  lab.test('test that similar object definition with different labels are not merged', async () => {
+    const testRoutes = [
+      {
+        method: 'POST',
+        path: '/users',
+        options: {
+          handler: Helper.defaultHandler,
+          description: 'Create new end-user',
+          notes: 'Create user',
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              name: Joi.string().required(),
+              email: Joi.string().email().required()
+            }).label('user')
+          }
+        }
+      },
+      {
+        method: 'POST',
+        path: '/admins',
+        options: {
+          handler: Helper.defaultHandler,
+          description: 'Create new admin',
+          notes: 'Create admin',
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              name: Joi.string().required(),
+              email: Joi.string().email().required()
+            }).label('admin')
+          }
+        }
+      },
+      {
+        method: 'PUT',
+        path: '/admins',
+        options: {
+          handler: Helper.defaultHandler,
+          description: 'Update admin',
+          notes: 'Update admin',
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              name: Joi.string().required(),
+              email: Joi.string().email().required()
+            }).label('admin')
+          }
+        }
+      },
+      {
+        method: 'PUT',
+        path: '/other',
+        options: {
+          handler: Helper.defaultHandler,
+          description: 'Other',
+          notes: 'Other',
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              name: Joi.string().required(),
+              email: Joi.string().email().required()
+            }).label('other')
+          }
+        }
+      },
+      {
+        method: 'PUT',
+        path: '/unknown',
+        options: {
+          handler: Helper.defaultHandler,
+          description: 'Unknown',
+          notes: 'Unknown',
+          tags: ['api'],
+          validate: {
+            payload: Joi.object({
+              name: Joi.string().required(),
+              email: Joi.string().email().required()
+            })
+          }
+        }
+      }
+    ];
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, testRoutes);
+
+    const response = await server.inject({ method: 'GET', url: '/openapi.json' });
+
+    expect(response.statusCode).to.equal(200);
+    expect(Object.keys(response.result.components.schemas).length).to.equal(4);
+    expect(Object.keys(response.result.components.schemas).includes('admin')).to.equal(true);
+    expect(Object.keys(response.result.components.schemas).includes('user')).to.equal(true);
+    expect(Object.keys(response.result.components.schemas).includes('other')).to.equal(true);
+    expect(Object.keys(response.result.components.schemas).includes('Model1')).to.equal(true);
+  });
+});

--- a/test/Integration/dereference-test.js
+++ b/test/Integration/dereference-test.js
@@ -59,6 +59,37 @@ lab.experiment('dereference', () => {
     expect(isValid).to.be.true();
   });
 
+  lab.test('flatten with no references (OpenAPI)', async () => {
+    const server = await Helper.createServer({ OAS: 'v3.0', deReference: true }, routes);
+    const response = await server.inject({ method: 'GET', url: '/openapi.json' });
+    expect(response.statusCode).to.equal(200);
+    expect(response.result.paths['/store/'].post.requestBody).to.equal({
+      content: {
+        'application/json': {
+          schema: {
+            properties: {
+              a: {
+                type: 'number'
+              },
+              b: {
+                type: 'number'
+              },
+              operator: {
+                type: 'string'
+              },
+              equals: {
+                type: 'number'
+              }
+            },
+            type: 'object'
+          }
+        }
+      }
+    });
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
   lab.test('dereferences error', async () => {
     try {
       await Builder.dereference(null);

--- a/test/Integration/parent-required-optional.js
+++ b/test/Integration/parent-required-optional.js
@@ -48,4 +48,15 @@ lab.experiment('path', () => {
     const isValid = await Validate.test(response.result);
     expect(isValid).to.be.true();
   });
+
+  lab.test('parent required should include required children (OpenAPI)', async () => {
+    // we need to set reuseDefinitions to false here otherwise,
+    // Request would be reused for Response as they're too similar
+    const server = await Helper.createServer({ OAS: 'v3.0', reuseDefinitions: false }, routes);
+    const response = await server.inject({ method: 'GET', url: '/openapi.json' });
+    expect(response.result.components.schemas.Request.required).to.equal(['requiredChild']);
+    expect(response.result.components.schemas.Response.required).to.equal(['requiredChild']);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
 });

--- a/test/Integration/proxy-openapi-test.js
+++ b/test/Integration/proxy-openapi-test.js
@@ -1,0 +1,409 @@
+const Code = require('@hapi/code');
+const Joi = require('joi');
+const Lab = require('@hapi/lab');
+const { clone } = require('@hapi/hoek');
+const Helper = require('../helper.js');
+const Validate = require('../../lib/validate.js');
+
+const expect = Code.expect;
+const lab = (exports.lab = Lab.script());
+
+lab.experiment('proxies (OpenAPI)', () => {
+  const requestOptions = {
+    method: 'GET',
+    url: '/openapi.json',
+    headers: {
+      host: 'hostyhost:12345',
+      referrer: 'http://localhost'
+    }
+  };
+
+  const routes = {
+    method: 'GET',
+    path: '/test',
+    handler: Helper.defaultHandler,
+    options: {
+      tags: ['api']
+    }
+  };
+
+  lab.test('basePath option', async () => {
+    const options = {
+      OAS: 'v3.0',
+      basePath: '/v2'
+    };
+
+    const server = await Helper.createServer(options, routes);
+    const response = await server.inject(requestOptions);
+    expect(response.statusCode).to.equal(200);
+    expect(response.result.servers).to.equal([{ url: 'http://localhost' + options.basePath }]);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('servers option', async () => {
+    const options = {
+      OAS: 'v3.0',
+      servers: [{ url: 'https://testhost' }]
+    };
+
+    const server = await Helper.createServer(options, routes);
+    const response = await server.inject(requestOptions);
+    expect(response.result.servers).to.equal([{ url: 'https://testhost' }]);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('referrer vs host and port', async () => {
+    const options = { OAS: 'v3.0' };
+
+    const server = await Helper.createServer(options, routes);
+    const response = await server.inject(requestOptions);
+    expect(response.result.servers).to.equal([{ url: `${requestOptions.headers.referrer}/` }]);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+    const clonedOptions = clone(requestOptions);
+    delete clonedOptions.headers.referrer;
+    const response2 = await server.inject(clonedOptions);
+    expect(response2.result.servers).to.equal([{ url: `http://${requestOptions.headers.host}` }]);
+    expect(await Validate.test(response2.result)).to.be.true();
+  });
+
+  lab.test('x-forwarded options', async () => {
+    const options = { OAS: 'v3.0' };
+
+    requestOptions.headers = {
+      'x-forwarded-host': 'proxyhost',
+      'x-forwarded-proto': 'https'
+    };
+
+    const server = await Helper.createServer(options, routes);
+    const response = await server.inject(requestOptions);
+    expect(response.result.servers).to.equal([{ url: `https://${requestOptions.headers['x-forwarded-host']}/` }]);
+  });
+
+  lab.test('x-forwarded options', async () => {
+    const options = { OAS: 'v3.0' };
+
+    requestOptions.headers = {
+      'x-forwarded-host': 'proxyhost',
+      'x-forwarded-proto': 'https'
+    };
+
+    const server = await Helper.createServer(options, routes);
+    const response = await server.inject(requestOptions);
+    expect(response.result.servers).to.equal([{ url: `https://${requestOptions.headers['x-forwarded-host']}/` }]);
+  });
+
+  lab.test('multi-hop x-forwarded options', async () => {
+    const options = { OAS: 'v3.0' };
+
+    requestOptions.headers = {
+      'x-forwarded-host': 'proxyhost,internalproxy',
+      'x-forwarded-proto': 'https,http'
+    };
+
+    const server = await Helper.createServer(options, routes);
+    const response = await server.inject(requestOptions);
+    expect(response.result.servers).to.equal([{ url: 'https://proxyhost/' }]);
+  });
+
+  lab.test('Azure Web Sites options', async () => {
+    const options = { OAS: 'v3.0' };
+
+    requestOptions.headers = {
+      'x-arr-ssl': 'information about the SSL server certificate',
+      'disguised-host': 'requested-host',
+      host: 'internal-host'
+    };
+
+    const server = await Helper.createServer(options, routes);
+    const response = await server.inject(requestOptions);
+    expect(response.result.servers).to.equal([{ url: `https://${requestOptions.headers['disguised-host']}/` }]);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('iisnode options', async () => {
+    const serverOptions = {
+      port: '\\\\.\\pipe\\GUID-expected-here'
+    };
+
+    const options = { OAS: 'v3.0' };
+
+    requestOptions.headers = {
+      'disguised-host': 'requested-host',
+      host: 'internal-host'
+    };
+
+    const server = await Helper.createServer(options, routes, serverOptions);
+    const response = await server.inject(requestOptions);
+
+    // Stop because otherwise consecutive test runs would error
+    // with EADDRINUSE.
+    await server.stop();
+
+    expect(response.result.servers).to.equal([{ url: `http://${requestOptions.headers['disguised-host']}/` }]);
+  });
+
+  lab.test('adding facade for proxy using route options 1', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/tools/microformats/',
+      options: {
+        tags: ['api'],
+        plugins: {
+          'hapi-swagger': {
+            nickname: 'microformatsapi',
+            validate: {
+              payload: Joi.object({
+                a: Joi.number().required().description('the first number'),
+                b: Joi.number().required().description('the first number')
+              }),
+              query: Joi.object({
+                testquery: Joi.string()
+              }),
+              params: Joi.object({
+                testparam: Joi.string()
+              }),
+              headers: Joi.object({
+                testheaders: Joi.string()
+              })
+            }
+          }
+        },
+        handler: {
+          proxy: {
+            host: 'glennjones.net',
+            protocol: 'http',
+            onResponse: Helper.replyWithJSON
+          }
+        }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject(requestOptions);
+
+    expect(response.result.paths['/tools/microformats/'].post.parameters).to.equal([
+      {
+        in: 'header',
+        name: 'testheaders',
+        schema: {
+          type: 'string'
+        }
+      },
+      {
+        in: 'path',
+        name: 'testparam',
+        schema: {
+          type: 'string'
+        }
+      },
+      {
+        in: 'query',
+        name: 'testquery',
+        schema: {
+          type: 'string'
+        }
+      }
+    ]);
+    expect(response.result.paths['/tools/microformats/'].post.requestBody).to.equal({
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Model1'
+          }
+        }
+      }
+    });
+  });
+
+  lab.test('adding facade for proxy using route options 2 - naming', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/tools/microformats/',
+      options: {
+        tags: ['api'],
+        plugins: {
+          'hapi-swagger': {
+            id: 'microformatsapi',
+            validate: {
+              payload: Joi.object({
+                a: Joi.number().required().description('the first number')
+              }).label('testname')
+            }
+          }
+        },
+        handler: {
+          proxy: {
+            host: 'glennjones.net',
+            protocol: 'http',
+            onResponse: Helper.replyWithJSON
+          }
+        }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject(requestOptions);
+
+    expect(response.result.paths['/tools/microformats/'].post.requestBody).to.equal({
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/testname'
+          }
+        }
+      }
+    });
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('adding facade for proxy using route options 3 - defination reuse', async () => {
+    const routes = [
+      {
+        method: 'POST',
+        path: '/tools/microformats/1',
+        options: {
+          tags: ['api'],
+          plugins: {
+            'hapi-swagger': {
+              id: 'microformatsapi1',
+              validate: {
+                payload: Joi.object({
+                  a: Joi.number().required().description('the first number')
+                }).label('testname')
+              }
+            }
+          },
+          handler: {
+            proxy: {
+              host: 'glennjones.net',
+              protocol: 'http',
+              onResponse: Helper.replyWithJSON
+            }
+          }
+        }
+      },
+      {
+        method: 'POST',
+        path: '/tools/microformats/2',
+        options: {
+          tags: ['api'],
+          plugins: {
+            'hapi-swagger': {
+              id: 'microformatsapi2',
+              validate: {
+                payload: Joi.object({
+                  a: Joi.number().required().description('the first number')
+                }).label('testname')
+              }
+            }
+          },
+          handler: {
+            proxy: {
+              host: 'glennjones.net',
+              protocol: 'http',
+              onResponse: Helper.replyWithJSON
+            }
+          }
+        }
+      }
+    ];
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject(requestOptions);
+
+    expect(response.result.components.schemas).to.equal({
+      testname: {
+        properties: {
+          a: {
+            type: 'number',
+            description: 'the first number'
+          }
+        },
+        required: ['a'],
+        type: 'object'
+      }
+    });
+  });
+
+  lab.test('adding facade for proxy using route options 4 - defination name clash', async () => {
+    const routes = [
+      {
+        method: 'POST',
+        path: '/tools/microformats/1',
+        options: {
+          tags: ['api'],
+          plugins: {
+            'hapi-swagger': {
+              id: 'microformatsapi1',
+              validate: {
+                payload: Joi.object({
+                  a: Joi.number().required().description('the first number')
+                }).label('testname')
+              }
+            }
+          },
+          handler: {
+            proxy: {
+              host: 'glennjones.net',
+              protocol: 'http',
+              onResponse: Helper.replyWithJSON
+            }
+          }
+        }
+      },
+      {
+        method: 'POST',
+        path: '/tools/microformats/2',
+        options: {
+          tags: ['api'],
+          plugins: {
+            'hapi-swagger': {
+              id: 'microformatsapi2',
+              validate: {
+                payload: Joi.object({
+                  b: Joi.string().description('the string')
+                }).label('testname')
+              }
+            }
+          },
+          handler: {
+            proxy: {
+              host: 'glennjones.net',
+              protocol: 'http',
+              onResponse: Helper.replyWithJSON
+            }
+          }
+        }
+      }
+    ];
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject(requestOptions);
+    expect(response.result.components.schemas).to.equal({
+      testname: {
+        properties: {
+          a: {
+            type: 'number',
+            description: 'the first number'
+          }
+        },
+        required: ['a'],
+        type: 'object'
+      },
+      Model1: {
+        properties: {
+          b: {
+            type: 'string',
+            description: 'the string'
+          }
+        },
+        type: 'object'
+      }
+    });
+  });
+});

--- a/test/Integration/query-openapi-test.js
+++ b/test/Integration/query-openapi-test.js
@@ -1,0 +1,234 @@
+const Code = require('@hapi/code');
+const Joi = require('joi');
+const Lab = require('@hapi/lab');
+const Helper = require('../helper.js');
+const Validate = require('../../lib/validate.js');
+
+const expect = Code.expect;
+const lab = (exports.lab = Lab.script());
+
+lab.experiment('query (OpenAPI)', () => {
+  lab.test('parameter required', async () => {
+    const testRoutes = [
+      {
+        method: 'GET',
+        path: '/required',
+        options: {
+          handler: () => {},
+          tags: ['api'],
+          validate: {
+            query: Joi.object({
+              requiredParameter: Joi.string().required(),
+              existParameter: Joi.string().exist(),
+              defaultParameter: Joi.string(),
+              optionalParameter: Joi.string().optional()
+            })
+          }
+        }
+      },
+      {
+        method: 'GET',
+        path: '/altParam',
+        options: {
+          handler: () => {},
+          tags: ['api'],
+          validate: {
+            query: Joi.object({
+              altParam: Joi.alternatives().try(Joi.number(), Joi.string())
+            })
+          }
+        }
+      }
+    ];
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, testRoutes);
+    const response = await server.inject({ method: 'GET', url: '/openapi.json' });
+    expect(response.statusCode).to.equal(200);
+    expect(response.result.paths['/required'].get.parameters).to.equal([
+      {
+        name: 'requiredParameter',
+        in: 'query',
+        required: true,
+        schema: {
+          type: 'string'
+        }
+      },
+      {
+        name: 'existParameter',
+        in: 'query',
+        required: true,
+        schema: {
+          type: 'string'
+        }
+      },
+      {
+        name: 'defaultParameter',
+        in: 'query',
+        schema: {
+          type: 'string'
+        }
+      },
+      {
+        name: 'optionalParameter',
+        in: 'query',
+        schema: {
+          type: 'string'
+        }
+      }
+    ]);
+
+    expect(response.result.paths['/altParam'].get.parameters).to.equal([
+      {
+        name: 'altParam',
+        in: 'query',
+        schema: {
+          anyOf: [{ type: 'number' }, { type: 'string' }]
+        }
+      }
+    ]);
+
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('parameter of object type', async () => {
+    const testRoutes = [
+      {
+        method: 'GET',
+        path: '/emptyobject',
+        options: {
+          tags: ['api'],
+          handler: () => {},
+          validate: {
+            query: Joi.object({
+              objParam: Joi.object()
+            })
+          }
+        }
+      },
+      {
+        method: 'GET',
+        path: '/objectWithProps',
+        options: {
+          tags: ['api'],
+          handler: () => {},
+          validate: {
+            query: Joi.object({
+              objParam: Joi.object({
+                stringParam: Joi.string()
+              })
+            })
+          }
+        }
+      },
+      {
+        method: 'GET',
+        path: '/arrayOfObjects',
+        options: {
+          tags: ['api'],
+          handler: () => {},
+          validate: {
+            query: Joi.object({
+              arrayParam: Joi.array().items({
+                stringParam: Joi.string()
+              })
+            })
+          }
+        }
+      },
+      {
+        method: 'GET',
+        path: '/arrayWithItemDescription',
+        options: {
+          tags: ['api'],
+          handler: () => {},
+          validate: {
+            query: Joi.object({
+              arrayParam: Joi.array()
+                .items(
+                  Joi.object({
+                    stringParam: Joi.string().description('String param description')
+                  }).description('Item description')
+                )
+                .description('Array description')
+            })
+          }
+        }
+      }
+    ];
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, testRoutes);
+    const response = await server.inject({ method: 'GET', url: '/openapi.json' });
+    expect(response.statusCode).to.equal(200);
+    expect(response.result.paths['/emptyobject'].get.parameters).to.equal([
+      {
+        name: 'objParam',
+        in: 'query',
+        schema: {
+          type: 'object'
+        }
+      }
+    ]);
+
+    expect(response.result.paths['/objectWithProps'].get.parameters).to.equal([
+      {
+        name: 'objParam',
+        in: 'query',
+        schema: {
+          type: 'object',
+          properties: {
+            stringParam: {
+              type: 'string'
+            }
+          }
+        }
+      }
+    ]);
+
+    expect(response.result.paths['/arrayOfObjects'].get.parameters).to.equal([
+      {
+        name: 'arrayParam',
+        in: 'query',
+        style: 'form',
+        explode: true,
+        schema: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              stringParam: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      }
+    ]);
+    expect(response.result.paths['/arrayWithItemDescription'].get.parameters).to.equal([
+      {
+        name: 'arrayParam',
+        in: 'query',
+        description: 'Array description',
+        style: 'form',
+        explode: true,
+        schema: {
+          type: 'array',
+          description: 'Array description',
+          items: {
+            type: 'object',
+            description: 'Item description',
+            properties: {
+              stringParam: {
+                type: 'string',
+                description: 'String param description'
+              }
+            }
+          }
+        }
+      }
+    ]);
+
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+});

--- a/test/Integration/responses-openapi-tests.js
+++ b/test/Integration/responses-openapi-tests.js
@@ -1,0 +1,923 @@
+const Code = require('@hapi/code');
+const Joi = require('joi');
+const Lab = require('@hapi/lab');
+const Helper = require('../helper.js');
+const Defaults = require('../../lib/defaults.js');
+const Responses = require('../../lib/responses.js');
+const Validate = require('../../lib/validate.js');
+
+const expect = Code.expect;
+const lab = (exports.lab = Lab.script());
+const responses = new Responses(Defaults);
+
+lab.experiment('responses', () => {
+  const headers = {
+    'X-Rate-Limit-Limit': {
+      description: 'The number of allowed requests in the current period',
+      schema: {
+        type: 'integer'
+      }
+    },
+    'X-Rate-Limit-Remaining': {
+      description: 'The number of remaining requests in the current period',
+      schema: {
+        type: 'integer'
+      }
+    },
+    'X-Rate-Limit-Reset': {
+      description: 'The number of seconds left in the current period',
+      schema: {
+        type: 'integer'
+      }
+    }
+  };
+
+  const examples = {
+    'application/json': {
+      a: 5,
+      b: 5,
+      operator: '+',
+      equals: 10
+    }
+  };
+
+  const err400 = Joi.object().description('Bad Request').meta({ headers, examples });
+  const err404 = Joi.object().description('Unsupported Media Type').meta({ headers, examples });
+  const err429 = Joi.object().description('Too Many Requests').meta({ headers, examples });
+  const err500 = Joi.object().description('Internal Server Error').meta({ headers, examples });
+
+  const joiSumModel = Joi.object({
+    id: Joi.string().required().example('x78P9c'),
+    a: Joi.number().required().example(5),
+    b: Joi.number().required().example(5),
+    operator: Joi.string().required().description('either +, -, /, or *').example('+'),
+    equals: Joi.number().required().example(10),
+    created: Joi.string().required().isoDate().description('ISO date string').example('2015-12-01'),
+    modified: Joi.string().isoDate().description('ISO date string').example('2015-12-01')
+  })
+    .description('json body for sum')
+    .label('Sum');
+
+  const joiListModel = Joi.object({
+    items: Joi.array().items(joiSumModel),
+    count: Joi.number().required(),
+    pageSize: Joi.number().required(),
+    page: Joi.number().required(),
+    pageCount: Joi.number().required()
+  }).label('List');
+
+  const standardHTTP = {
+    200: {
+      description: 'Success',
+      schema: joiSumModel,
+      headers
+    },
+    400: {
+      description: 'Bad Request',
+      headers
+    },
+    429: {
+      description: 'Too Many Requests',
+      headers
+    },
+    500: {
+      description: 'Internal Server Error',
+      headers
+    }
+  };
+
+  lab.test('using hapi response.schema', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        validate: {
+          payload: Joi.object({
+            a: Joi.number().required().description('the first number')
+          })
+        },
+        payload: {
+          maxBytes: 1048576,
+          parse: true,
+          output: 'stream'
+        },
+        response: { schema: joiSumModel }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.paths['/store/'].post.responses).to.exist();
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('conditional variables produce `required = true`, not `required = [...]`', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        validate: {
+          query: Joi.object({
+            nonce: Joi.string().when('response_type', {
+              is: /^id_token( token)?$/,
+              then: Joi.required()
+            }),
+            response_type: Joi.string().allow('@hapi/code', 'id_token token', 'id_token').required()
+          })
+        }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.paths['/store/'].post.parameters[0].required).to.equal(true);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('using hapi response.schema with child objects', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        validate: {
+          payload: Joi.object({
+            a: Joi.number().required().description('the first number')
+          })
+        },
+        payload: {
+          maxBytes: 1048576,
+          parse: true,
+          output: 'stream'
+        },
+        response: { schema: joiListModel }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.components.schemas.List).to.exist();
+    expect(response.result.components.schemas.Sum).to.exist();
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('using hapi response.status', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        validate: {
+          payload: Joi.object({
+            a: Joi.number().required().description('the first number')
+          })
+        },
+        response: {
+          status: {
+            200: joiSumModel,
+            204: undefined,
+            400: err400,
+            404: err404,
+            429: err429,
+            500: err500
+          }
+        }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.paths['/store/'].post.responses[200]).to.exist();
+    expect(response.result.paths['/store/'].post.responses[204].description).to.equal('No Content');
+    expect(response.result.paths['/store/'].post.responses[400].description).to.equal('Bad Request');
+    expect(response.result.paths['/store/'].post.responses[400].headers).to.equal(headers);
+    expect(response.result.paths['/store/'].post.responses[400].content['application/json'].example).to.equal(examples);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('using hapi response.status without 200', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        validate: {
+          payload: Joi.object({
+            a: Joi.number().required().description('the first number')
+          })
+        },
+        response: {
+          status: {
+            400: err400,
+            404: err404,
+            429: err429,
+            500: err500
+          }
+        }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.paths['/store/'].post.responses[200]).to.equal(undefined);
+    expect(response.result.paths['/store/'].post.responses[400].description).to.equal('Bad Request');
+    expect(response.result.paths['/store/'].post.responses[400].headers).to.equal(headers);
+    expect(response.result.paths['/store/'].post.responses[400].content['application/json'].example).to.equal(examples);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('using route base plugin override - object', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        plugins: {
+          'hapi-swagger': {
+            responses: standardHTTP
+          }
+        },
+        validate: {
+          payload: Joi.object({
+            a: Joi.number().required().description('the first number')
+          })
+        }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.paths['/store/'].post.responses[200].content['application/json'].schema).to.exist();
+    expect(response.result.paths['/store/'].post.responses[400].description).to.equal('Bad Request');
+    expect(response.result.paths['/store/'].post.responses[400].headers).to.equal(headers);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('using route merging response and plugin override', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      handler: Helper.defaultHandler,
+      options: {
+        tags: ['api'],
+        response: {
+          schema: Joi.object().keys({ test: Joi.string() }).label('Result')
+        },
+        plugins: {
+          'hapi-swagger': {
+            responses: {
+              200: {
+                description: 'Success its a 200',
+                'x-meta': 'x-meta test data'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.paths['/store/'].post.responses[200].content['application/json'].schema).to.exist();
+    expect(response.result.paths['/store/'].post.responses[200].description).to.equal('Success its a 200');
+    expect(response.result.paths['/store/'].post.responses[200]['x-meta']).to.equal('x-meta test data');
+    expect(response.result.paths['/store/'].post.responses[200].content['application/json'].schema).to.equal({
+      $ref: '#/components/schemas/Result'
+    });
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('test a default response description is provided when no description is given', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      handler: Helper.defaultHandler,
+      options: {
+        tags: ['api'],
+        plugins: {
+          'hapi-swagger': {
+            responses: {
+              200: {
+                'x-meta': 'x-meta test data'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.paths['/store/'].post.responses[200].description).to.equal('Successful');
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('using route base plugin override - array', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        plugins: {
+          'hapi-swagger': {
+            responses: {
+              200: {
+                description: 'Success',
+                schema: Joi.array()
+                  .items(
+                    Joi.object({
+                      equals: Joi.number()
+                    }).label('HTTP200Items')
+                  )
+                  .label('HTTP200')
+              },
+              400: {
+                description: 'Bad Request',
+                schema: Joi.array()
+                  .items(
+                    Joi.object({
+                      equals: Joi.string()
+                    })
+                  )
+                  .label('HTTP400')
+              }
+            }
+          }
+        },
+        validate: {
+          payload: Joi.object({
+            a: Joi.number().required().description('the first number')
+          }).label('Payload')
+        }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.paths['/store/'].post.responses[200]).to.equal({
+      description: 'Success',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/HTTP200'
+          }
+        }
+      }
+    });
+    expect(response.result.components.schemas.HTTP200).to.equal({
+      type: 'array',
+      items: {
+        $ref: '#/components/schemas/HTTP200Items'
+      }
+    });
+    expect(response.result.components.schemas.HTTP200Items).to.equal({
+      type: 'object',
+      properties: {
+        equals: {
+          type: 'number'
+        }
+      }
+    });
+    expect(response.result.paths['/store/'].post.responses[400].description).to.equal('Bad Request');
+    expect(response.result.components.schemas.HTTP400).exists();
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('failback to 200', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        validate: {
+          payload: Joi.object({
+            a: Joi.number().required().description('the first number')
+          })
+        }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.paths['/store/'].post.responses).to.equal({
+      default: {
+        content: {
+          'application/json': {
+            schema: {
+              type: 'string'
+            }
+          }
+        },
+        description: 'Successful'
+      }
+    });
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('when default schema provided an no responses provided', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        validate: {
+          payload: Joi.object({
+            a: Joi.number().required().description('the first number')
+          })
+        },
+        response: {
+          schema: joiListModel
+        }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.paths['/store/'].post.responses).to.equal({
+      200: {
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/List'
+            }
+          }
+        },
+        description: 'Successful'
+      }
+    });
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('No ownProperty', () => {
+    const objA = Helper.objWithNoOwnProperty();
+    const objB = Helper.objWithNoOwnProperty();
+    const objC = Helper.objWithNoOwnProperty();
+
+    expect(responses.build({}, {}, {}, {})).to.equal({
+      default: {
+        schema: {
+          type: 'string'
+        },
+        description: 'Successful'
+      }
+    });
+    expect(responses.build(objA, objB, objC, {})).to.equal({
+      default: {
+        schema: {
+          type: 'string'
+        },
+        description: 'Successful'
+      }
+    });
+
+    const objD = { 200: { description: 'Successful' } };
+    expect(responses.build(objD, objB, objC, {})).to.equal({
+      200: {
+        schema: {
+          type: 'string'
+        },
+        description: 'Successful'
+      }
+    });
+  });
+
+  lab.test('with same path but different method', async () => {
+    const routes = [
+      {
+        method: 'POST',
+        path: '/path/two',
+        options: {
+          tags: ['api'],
+          handler: Helper.defaultHandler,
+          response: {
+            schema: Joi.object({
+              value1111: Joi.boolean()
+            })
+          }
+        }
+      },
+      {
+        method: 'GET',
+        path: '/path/two',
+        options: {
+          tags: ['api'],
+          handler: Helper.defaultHandler,
+          response: {
+            schema: Joi.object({
+              value2222: Joi.boolean()
+            })
+          }
+        }
+      }
+    ];
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.components.schemas.Model1).to.exist();
+    expect(response.result.components.schemas.Model2).to.exist();
+    expect(response.result.components.schemas).to.equal({
+      Model1: {
+        type: 'object',
+        properties: {
+          value2222: {
+            type: 'boolean'
+          }
+        }
+      },
+      Model2: {
+        type: 'object',
+        properties: {
+          value1111: {
+            type: 'boolean'
+          }
+        }
+      }
+    });
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('with deep labels', async () => {
+    const routes = [
+      {
+        method: 'POST',
+        path: '/path/two',
+        options: {
+          tags: ['api'],
+          handler: Helper.defaultHandler,
+          response: {
+            schema: Joi.object({
+              value1111: Joi.boolean()
+            }).label('labelA')
+          }
+        }
+      }
+    ];
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.components.schemas.labelA).to.exist();
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('array with required #249', async () => {
+    const dataPointSchema = Joi.object()
+      .keys({
+        date: Joi.date().required(),
+        value: Joi.number().required()
+      })
+      .label('datapoint')
+      .required();
+
+    const exampleSchema = Joi.array().items(dataPointSchema).label('datapointlist').required();
+
+    const routes = [
+      {
+        method: 'POST',
+        path: '/path/two',
+        options: {
+          tags: ['api'],
+          handler: Helper.defaultHandler,
+          response: { schema: exampleSchema }
+        }
+      }
+    ];
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.components.schemas.datapoint).to.exist();
+    expect(response.result.components.schemas).to.equal({
+      datapoint: {
+        properties: {
+          date: {
+            type: 'string',
+            format: 'date'
+          },
+          value: {
+            type: 'number'
+          }
+        },
+        required: ['date', 'value'],
+        type: 'object'
+      },
+      datapointlist: {
+        type: 'array',
+        items: {
+          $ref: '#/components/schemas/datapoint'
+        }
+      }
+    });
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('replace example with x-example for response', async () => {
+    const dataPointSchema = Joi.object()
+      .keys({
+        date: Joi.date().required().example('2016-08-26'),
+        value: Joi.number().required().example('1024')
+      })
+      .label('datapoint')
+      .required();
+
+    const exampleSchema = Joi.array().items(dataPointSchema).label('datapointlist').required();
+
+    const routes = [
+      {
+        method: 'POST',
+        path: '/path/two',
+        options: {
+          tags: ['api'],
+          handler: Helper.defaultHandler,
+          response: { schema: exampleSchema }
+        }
+      }
+    ];
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.components.schemas.datapoint).to.exist();
+    expect(response.result.components.schemas).to.equal({
+      datapoint: {
+        properties: {
+          date: {
+            type: 'string',
+            format: 'date',
+            example: '2016-08-26'
+          },
+          value: {
+            type: 'number',
+            example: '1024'
+          }
+        },
+        required: ['date', 'value'],
+        type: 'object'
+      },
+      datapointlist: {
+        type: 'array',
+        items: {
+          $ref: '#/components/schemas/datapoint'
+        }
+      }
+    });
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('using hapi response.schema and plugin ', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        plugins: {
+          'hapi-swagger': {
+            responses: {
+              200: {
+                description: 'Success with response.schema'
+              }
+            }
+          }
+        },
+        response: { schema: joiListModel }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.paths).to.equal({
+      '/store/': {
+        post: {
+          operationId: 'postStore',
+          tags: ['store'],
+          responses: {
+            200: {
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/List'
+                  }
+                }
+              },
+              description: 'Success with response.schema'
+            }
+          }
+        }
+      }
+    });
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('using hapi response.schema and plugin mismatch', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        plugins: {
+          'hapi-swagger': {
+            responses: {
+              404: {
+                description: 'Could not find a schema'
+              }
+            }
+          }
+        },
+        response: { schema: joiListModel }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.paths).to.equal({
+      '/store/': {
+        post: {
+          operationId: 'postStore',
+          tags: ['store'],
+          responses: {
+            200: {
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/List'
+                  }
+                }
+              },
+              description: 'Successful'
+            },
+            404: {
+              description: 'Could not find a schema'
+            }
+          }
+        }
+      }
+    });
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('using hapi response.schema and plugin mismatch', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        plugins: {
+          'hapi-swagger': {
+            responses: {
+              200: {
+                description: 'Success with response.schema',
+                schema: joiSumModel
+              }
+            }
+          }
+        },
+        response: { schema: joiListModel }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.paths).to.equal({
+      '/store/': {
+        post: {
+          operationId: 'postStore',
+          tags: ['store'],
+          responses: {
+            200: {
+              description: 'Success with response.schema',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/Sum'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('using hapi response.schema and plugin mixed results', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        plugins: {
+          'hapi-swagger': {
+            responses: {
+              400: {
+                description: '400 - Added from plugin-options'
+              },
+              404: {
+                schema: Joi.object({ err: Joi.string() })
+              },
+              500: {
+                description: '500 - Added from plugin-options'
+              }
+            }
+          }
+        },
+        response: {
+          status: {
+            200: joiSumModel,
+            400: Joi.object({ err: Joi.string() }),
+            404: Joi.object({ err: Joi.string() }).description('404 from response status object'),
+            429: Joi.object({ err: Joi.string() })
+          }
+        }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, routes);
+    const response = await server.inject({ url: '/openapi.json' });
+    expect(response.result.paths).to.equal({
+      '/store/': {
+        post: {
+          operationId: 'postStore',
+          tags: ['store'],
+          responses: {
+            200: {
+              description: 'json body for sum',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/Sum'
+                  }
+                }
+              }
+            },
+            400: {
+              description: '400 - Added from plugin-options',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/Model1'
+                  }
+                }
+              }
+            },
+            404: {
+              description: '404 from response status object',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/Model4'
+                  }
+                }
+              }
+            },
+            429: {
+              description: 'Too Many Requests',
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/Model3'
+                  }
+                }
+              }
+            },
+            500: {
+              description: '500 - Added from plugin-options'
+            }
+          }
+        }
+      }
+    });
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+});

--- a/test/Integration/security-openapi-test.js
+++ b/test/Integration/security-openapi-test.js
@@ -1,0 +1,191 @@
+const Code = require('@hapi/code');
+const Joi = require('joi');
+const Lab = require('@hapi/lab');
+const Helper = require('../helper.js');
+const Validate = require('../../lib/validate.js');
+
+const expect = Code.expect;
+const lab = (exports.lab = Lab.script());
+
+lab.experiment('security (OpenAPI)', () => {
+  // example from https://petstore3.swagger.io/api/v3/openapi.json
+  const swaggerOptions = {
+    OAS: 'v3.0',
+    securityDefinitions: {
+      petstore_auth: {
+        type: 'oauth2',
+        flows: {
+          implicit: {
+            authorizationUrl: 'https://petstore3.swagger.io/oauth/authorize',
+            scopes: {
+              'write:pets': 'modify pets in your account',
+              'read:pets': 'read your pets'
+            }
+          }
+        }
+      },
+      api_key: {
+        type: 'apiKey',
+        name: 'api_key',
+        in: 'header',
+        'x-keyPrefix': 'Bearer '
+      }
+    },
+    security: [{ api_key: [] }]
+  };
+
+  // route with examples of security objects from https://petstore3.swagger.io/api/v3/openapi.json
+  const routes = [
+    {
+      method: 'POST',
+      path: '/bookmarks/1/',
+      options: {
+        handler: Helper.defaultHandler,
+        plugins: {
+          'hapi-swagger': {
+            payloadType: 'form',
+            security: [{ api_key: [] }]
+          }
+        },
+        tags: ['api'],
+        validate: {
+          payload: Joi.object({
+            url: Joi.string().required().description('the url to bookmark')
+          })
+        }
+      }
+    },
+    {
+      method: 'POST',
+      path: '/bookmarks/2/',
+      options: {
+        handler: Helper.defaultHandler,
+        plugins: {
+          'hapi-swagger': {
+            payloadType: 'form',
+            security: [
+              {
+                petstore_auth: ['write:pets', 'read:pets']
+              }
+            ]
+          }
+        },
+        tags: ['api'],
+        validate: {
+          payload: Joi.object({
+            url: Joi.string().required().description('the url to bookmark')
+          })
+        }
+      }
+    }
+  ];
+
+  lab.test('passes through securityDefinitions', async () => {
+    const requestOptions = {
+      method: 'GET',
+      url: '/openapi.json',
+      headers: {
+        authorization: 'Bearer 12345'
+      }
+    };
+
+    const server = await Helper.createServer(swaggerOptions, routes);
+    const response = await server.inject(requestOptions);
+    expect(response.result.components.securitySchemes).to.equal(swaggerOptions.securityDefinitions);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('passes through security objects for whole api', async () => {
+    const requestOptions = {
+      method: 'GET',
+      url: '/openapi.json'
+    };
+
+    // plugin routes should be not be affected by auth on API
+    const server = await Helper.createServer(swaggerOptions, routes);
+    const response = await server.inject(requestOptions);
+    expect(response.result.security).to.equal(swaggerOptions.security);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('passes through security objects on routes', async () => {
+    const requestOptions = {
+      method: 'GET',
+      url: '/openapi.json'
+    };
+
+    // plugin routes should be not be affected by auth on API
+    const server = await Helper.createServer(swaggerOptions, routes);
+    const response = await server.inject(requestOptions);
+    expect(response.result.paths['/bookmarks/1/'].post.security).to.equal([
+      {
+        api_key: []
+      }
+    ]);
+    expect(response.result.paths['/bookmarks/2/'].post.security).to.equal([
+      {
+        petstore_auth: ['write:pets', 'read:pets']
+      }
+    ]);
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
+  // lab.test('passes through x-keyPrefix', async() => {
+
+  //     const prefixBearerOptions = {
+  //         debug: true,
+  //         securityDefinitions: {
+  //             'Bearer': {
+  //                 'type': 'apiKey',
+  //                 'name': 'Authorization',
+  //                 'in': 'header',
+  //                 'x-keyPrefix': 'Bearer '
+  //             }
+  //         },
+  //         security: [{ 'Bearer': [] }]
+  //     };
+
+  //     const requestOptions = {
+  //         method: 'GET',
+  //         url: '/documentation/debug'
+  //     };
+
+  //     // plugin routes should be not be affected by auth on API
+  //     const server = await Helper.createServer(prefixBearerOptions, routes);
+  //     const response = await server.inject(requestOptions);
+  //     expect(JSON.parse(response.result).keyPrefix).to.equal('Bearer ');
+  // });
+
+  // lab.test('no keyPrefix', async() => {
+
+  //     const prefixOauth2Options = {
+  //         debug: true,
+  //         securityDefinitions: {
+  //             'Oauth2': {
+  //                 'type': 'oauth2',
+  //                 'authorizationUrl': 'http://petstore.swagger.io/api/oauth/dialog',
+  //                 'flow': 'implicit',
+  //                 'scopes': {
+  //                     'write:pets': 'modify pets in your account',
+  //                     'read:pets': 'read your pets'
+  //                 }
+  //             }
+  //         },
+  //         security: [{ 'Oauth2': [] }]
+  //     };
+
+  //     const requestOptions = {
+  //         method: 'GET',
+  //         url: '/documentation/debug'
+  //     };
+
+  //     // plugin routes should be not be affected by auth on API
+  //     const server = await Helper.createServer(prefixOauth2Options, routes);
+  //     const response = await server.inject(requestOptions);
+  //     expect(JSON.parse(response.result).keyPrefix).to.equal(undefined);
+
+  // });
+});

--- a/test/Integration/sorted-test.js
+++ b/test/Integration/sorted-test.js
@@ -6,134 +6,143 @@ const Validate = require('../../lib/validate.js');
 const expect = Code.expect;
 const lab = (exports.lab = Lab.script());
 
-lab.experiment('sort', () => {
-  const routes = [
-    {
-      method: 'POST',
-      path: '/x',
-      options: {
-        tags: ['api'],
-        handler: Helper.defaultHandler,
-        plugins: {
-          'hapi-swagger': {
-            order: 7
-          }
-        }
-      }
-    },
-    {
-      method: 'GET',
-      path: '/b',
-      options: {
-        tags: ['api'],
-        handler: Helper.defaultHandler,
-        plugins: {
-          'hapi-swagger': {
-            order: 5
-          }
-        }
-      }
-    },
-    {
-      method: 'GET',
-      path: '/b/c',
-      options: {
-        tags: ['api'],
-        handler: Helper.defaultHandler,
-        plugins: {
-          'hapi-swagger': {
-            order: 4
-          }
-        }
-      }
-    },
-    {
-      method: 'POST',
-      path: '/b/c/d',
-      options: {
-        tags: ['api'],
-        handler: Helper.defaultHandler,
-        plugins: {
-          'hapi-swagger': {
-            order: 1
-          }
-        }
-      }
-    },
-    {
-      method: 'GET',
-      path: '/b/c/d',
-      options: {
-        tags: ['api'],
-        handler: Helper.defaultHandler,
-        plugins: {
-          'hapi-swagger': {
-            order: 2
-          }
-        }
-      }
-    },
-    {
-      method: 'DELETE',
-      path: '/a',
-      options: {
-        tags: ['api'],
-        handler: Helper.defaultHandler,
-        plugins: {
-          'hapi-swagger': {
-            order: 3
-          }
-        }
-      }
-    },
-    {
-      method: 'POST',
-      path: '/a',
-      options: {
-        tags: ['api'],
-        handler: Helper.defaultHandler,
-        plugins: {
-          'hapi-swagger': {
-            order: 7
-          }
-        }
-      }
-    },
-    {
-      method: 'GET',
-      path: '/a',
-      options: {
-        tags: ['api'],
-        handler: Helper.defaultHandler,
-        plugins: {
-          'hapi-swagger': {
-            order: 6
-          }
-        }
-      }
-    }
-  ];
+const versions = ['v2', 'v3.0'];
 
-  /* These test are no longer needed `sortPaths` is to be deprecate
+versions.forEach((version) => {
+  lab.experiment(`OAS ${version}`, () => {
+    lab.experiment('sort', () => {
+      const routes = [
+        {
+          method: 'POST',
+          path: '/x',
+          options: {
+            tags: ['api'],
+            handler: Helper.defaultHandler,
+            plugins: {
+              'hapi-swagger': {
+                order: 7
+              }
+            }
+          }
+        },
+        {
+          method: 'GET',
+          path: '/b',
+          options: {
+            tags: ['api'],
+            handler: Helper.defaultHandler,
+            plugins: {
+              'hapi-swagger': {
+                order: 5
+              }
+            }
+          }
+        },
+        {
+          method: 'GET',
+          path: '/b/c',
+          options: {
+            tags: ['api'],
+            handler: Helper.defaultHandler,
+            plugins: {
+              'hapi-swagger': {
+                order: 4
+              }
+            }
+          }
+        },
+        {
+          method: 'POST',
+          path: '/b/c/d',
+          options: {
+            tags: ['api'],
+            handler: Helper.defaultHandler,
+            plugins: {
+              'hapi-swagger': {
+                order: 1
+              }
+            }
+          }
+        },
+        {
+          method: 'GET',
+          path: '/b/c/d',
+          options: {
+            tags: ['api'],
+            handler: Helper.defaultHandler,
+            plugins: {
+              'hapi-swagger': {
+                order: 2
+              }
+            }
+          }
+        },
+        {
+          method: 'DELETE',
+          path: '/a',
+          options: {
+            tags: ['api'],
+            handler: Helper.defaultHandler,
+            plugins: {
+              'hapi-swagger': {
+                order: 3
+              }
+            }
+          }
+        },
+        {
+          method: 'POST',
+          path: '/a',
+          options: {
+            tags: ['api'],
+            handler: Helper.defaultHandler,
+            plugins: {
+              'hapi-swagger': {
+                order: 7
+              }
+            }
+          }
+        },
+        {
+          method: 'GET',
+          path: '/a',
+          options: {
+            tags: ['api'],
+            handler: Helper.defaultHandler,
+            plugins: {
+              'hapi-swagger': {
+                order: 6
+              }
+            }
+          }
+        }
+      ];
 
-    lab.test('sort ordered unsorted', (done) => {
+      /* These test are no longer needed `sortPaths` is to be deprecate
 
-        Helper.createServer({ sortPaths: 'unsorted' }, routes, (err, server) => {
-            server.inject({ method: 'GET', url: '/swagger.json' }, function (response) {
+        lab.test('sort ordered unsorted', (done) => {
 
-                //console.log(JSON.stringify(response.result.paths['/a']));
-                expect(Object.keys(response.result.paths['/a'])).to.equal(['post', 'get', 'delete']);
-                done();
+            Helper.createServer({ sortPaths: 'unsorted' }, routes, (err, server) => {
+                server.inject({ method: 'GET', url: '/swagger.json' }, function (response) {
+
+                    //console.log(JSON.stringify(response.result.paths['/a']));
+                    expect(Object.keys(response.result.paths['/a'])).to.equal(['post', 'get', 'delete']);
+                    done();
+                });
             });
         });
-    });
-     */
+         */
 
-  lab.test('sort ordered path-method', async () => {
-    const server = await Helper.createServer({ sortPaths: 'path-method' }, routes);
-    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
-    expect(Object.keys(response.result.paths['/a'])).to.equal(['delete', 'get', 'post']);
-    const isValid = await Validate.test(response.result);
-    expect(isValid).to.be.true();
+      lab.test('sort ordered path-method', async () => {
+        const server = await Helper.createServer({ OAS: version, sortPaths: 'path-method' }, routes);
+        const response = await server.inject({
+          method: 'GET',
+          url: version === 'v2' ? '/swagger.json' : '/openapi.json'
+        });
+        expect(Object.keys(response.result.paths['/a'])).to.equal(['delete', 'get', 'post']);
+        const isValid = await Validate.test(response.result);
+        expect(isValid).to.be.true();
+      });
+    });
   });
 });

--- a/test/Integration/tags-test.js
+++ b/test/Integration/tags-test.js
@@ -6,65 +6,74 @@ const Validate = require('../../lib/validate.js');
 const expect = Code.expect;
 const lab = (exports.lab = Lab.script());
 
-lab.experiment('tags', () => {
-  const routes = [
-    {
-      method: 'GET',
-      path: '/test',
-      handler: Helper.defaultHandler,
-      options: {
-        tags: ['api']
-      }
-    }
-  ];
+const versions = ['v2', 'v3.0'];
+versions.forEach((version) => {
+  const jsonUrl = version === 'v2' ? '/swagger.json' : '/openapi.json';
 
-  lab.test('no tag objects passed', async () => {
-    const server = await Helper.createServer({}, routes);
-    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
-    expect(response.statusCode).to.equal(200);
-    expect(response.result.tags).to.equal([]);
-    const isValid = await Validate.test(response.result);
-    expect(isValid).to.be.true();
-  });
-
-  lab.test('name property passed', async () => {
-    const swaggerOptions = {
-      tags: [
+  lab.experiment(`OAS ${version}`, () => {
+    lab.experiment('tags', () => {
+      const routes = [
         {
-          name: 'test'
-        }
-      ]
-    };
-
-    const server = await Helper.createServer(swaggerOptions, routes);
-    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
-    expect(response.statusCode).to.equal(200);
-    expect(response.result.tags[0].name).to.equal('test');
-
-    const isValid = await Validate.test(response.result);
-    expect(isValid).to.be.true();
-  });
-
-  lab.test('full tag object', async () => {
-    const swaggerOptions = {
-      tags: [
-        {
-          name: 'test',
-          description: 'Everything about test',
-          externalDocs: {
-            description: 'Find out more',
-            url: 'http://swagger.io'
+          method: 'GET',
+          path: '/test',
+          handler: Helper.defaultHandler,
+          options: {
+            tags: ['api']
           }
         }
-      ]
-    };
+      ];
 
-    const server = await Helper.createServer(swaggerOptions, routes);
-    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+      lab.test('no tag objects passed', async () => {
+        const server = await Helper.createServer({ OAS: version }, routes);
+        const response = await server.inject({ method: 'GET', url: jsonUrl });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.tags).to.equal([]);
+        const isValid = await Validate.test(response.result);
+        expect(isValid).to.be.true();
+      });
 
-    expect(response.statusCode).to.equal(200);
-    expect(response.result.tags).to.equal(swaggerOptions.tags);
-    const isValid = await Validate.test(response.result);
-    expect(isValid).to.be.true();
+      lab.test('name property passed', async () => {
+        const swaggerOptions = {
+          OAS: version,
+          tags: [
+            {
+              name: 'test'
+            }
+          ]
+        };
+
+        const server = await Helper.createServer(swaggerOptions, routes);
+        const response = await server.inject({ method: 'GET', url: jsonUrl });
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.tags[0].name).to.equal('test');
+
+        const isValid = await Validate.test(response.result);
+        expect(isValid).to.be.true();
+      });
+
+      lab.test('full tag object', async () => {
+        const swaggerOptions = {
+          OAS: version,
+          tags: [
+            {
+              name: 'test',
+              description: 'Everything about test',
+              externalDocs: {
+                description: 'Find out more',
+                url: 'http://swagger.io'
+              }
+            }
+          ]
+        };
+
+        const server = await Helper.createServer(swaggerOptions, routes);
+        const response = await server.inject({ method: 'GET', url: jsonUrl });
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.tags).to.equal(swaggerOptions.tags);
+        const isValid = await Validate.test(response.result);
+        expect(isValid).to.be.true();
+      });
+    });
   });
 });

--- a/test/Integration/wildcard-routes.js
+++ b/test/Integration/wildcard-routes.js
@@ -6,88 +6,95 @@ const Validate = require('../../lib/validate.js');
 const expect = Code.expect;
 const lab = (exports.lab = Lab.script());
 
-lab.experiment('wildcard routes', () => {
-  lab.test('method *', async () => {
-    const routes = {
-      method: '*',
-      path: '/test',
-      handler: Helper.defaultHandler,
-      options: {
-        tags: ['api'],
-        notes: 'test'
-      }
-    };
+const versions = ['v2', 'v3.0'];
+versions.forEach((version) => {
+  const jsonUrl = version === 'v2' ? '/swagger.json' : '/openapi.json';
 
-    const server = await Helper.createServer({}, routes);
-    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+  lab.experiment(`OAS ${version}`, () => {
+    lab.experiment('wildcard routes', () => {
+      lab.test('method *', async () => {
+        const routes = {
+          method: '*',
+          path: '/test',
+          handler: Helper.defaultHandler,
+          options: {
+            tags: ['api'],
+            notes: 'test'
+          }
+        };
 
-    expect(response.statusCode).to.equal(200);
-    expect(response.result.paths['/test']).to.have.length(5);
-    expect(response.result.paths['/test']).to.include('get');
-    expect(response.result.paths['/test']).to.include('post');
-    expect(response.result.paths['/test']).to.include('put');
-    expect(response.result.paths['/test']).to.include('patch');
-    expect(response.result.paths['/test']).to.include('delete');
-  });
+        const server = await Helper.createServer({ OAS: version }, routes);
+        const response = await server.inject({ method: 'GET', url: jsonUrl });
 
-  lab.test('method * with custom methods', async () => {
-    const routes = {
-      method: '*',
-      path: '/test',
-      handler: Helper.defaultHandler,
-      options: {
-        tags: ['api'],
-        notes: 'test'
-      }
-    };
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.paths['/test']).to.have.length(5);
+        expect(response.result.paths['/test']).to.include('get');
+        expect(response.result.paths['/test']).to.include('post');
+        expect(response.result.paths['/test']).to.include('put');
+        expect(response.result.paths['/test']).to.include('patch');
+        expect(response.result.paths['/test']).to.include('delete');
+      });
 
-    const server = await Helper.createServer({wildcardMethods: ['GET', 'QUERY']}, routes);
-    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+      lab.test('method * with custom methods', async () => {
+        const routes = {
+          method: '*',
+          path: '/test',
+          handler: Helper.defaultHandler,
+          options: {
+            tags: ['api'],
+            notes: 'test'
+          }
+        };
 
-    expect(response.statusCode).to.equal(200);
-    expect(response.result.paths['/test']).to.have.length(2);
-    expect(response.result.paths['/test']).to.include('get');
-    expect(response.result.paths['/test']).to.include('query');
-  });
+        const server = await Helper.createServer({ OAS: version, wildcardMethods: ['GET', 'QUERY'] }, routes);
+        const response = await server.inject({ method: 'GET', url: jsonUrl });
 
-  lab.test('method * with not allowed custom methods', async () => {
-    try {
-      const routes = {
-        method: '*',
-        path: '/test',
-        handler: Helper.defaultHandler,
-        options: {
-          tags: ['api'],
-          notes: 'test'
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.paths['/test']).to.have.length(2);
+        expect(response.result.paths['/test']).to.include('get');
+        expect(response.result.paths['/test']).to.include('query');
+      });
+
+      lab.test('method * with not allowed custom methods', async () => {
+        try {
+          const routes = {
+            method: '*',
+            path: '/test',
+            handler: Helper.defaultHandler,
+            options: {
+              tags: ['api'],
+              notes: 'test'
+            }
+          };
+
+          await Helper.createServer({ OAS: version, wildcardMethods: ['HEAD', 'OPTIONS'] }, routes);
+        } catch (err) {
+          expect(err).to.exists();
+          expect(err.message).include('wildcardMethods');
         }
-      };
+      });
 
-      await Helper.createServer({ wildcardMethods: ['HEAD', 'OPTIONS'] }, routes);
-    } catch (err) {
-      expect(err).to.exists();
-      expect(err.message).include('wildcardMethods');
-    }
-  });
+      lab.test('method array [GET, POST]', async () => {
+        const routes = {
+          method: ['GET', 'POST'],
+          path: '/test',
+          handler: Helper.defaultHandler,
+          options: {
+            tags: ['api'],
+            notes: 'test'
+          }
+        };
 
-  lab.test('method array [GET, POST]', async () => {
-    const routes = {
-      method: ['GET', 'POST'],
-      path: '/test',
-      handler: Helper.defaultHandler,
-      options: {
-        tags: ['api'],
-        notes: 'test'
-      }
-    };
+        const server = await Helper.createServer({ OAS: version }, routes);
+        const response = await server.inject({ method: 'GET', url: jsonUrl });
 
-    const server = await Helper.createServer({}, routes);
-    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
-
-    expect(response.statusCode).to.equal(200);
-    expect(response.result.paths['/test']).to.have.length(2);
-    expect(response.result.paths['/test']).to.include('get');
-    expect(response.result.paths['/test']).to.include('post');
-    const isValid = await Validate.test(response.result);
-    expect(isValid).to.be.true();
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.paths['/test']).to.have.length(2);
+        expect(response.result.paths['/test']).to.include('get');
+        expect(response.result.paths['/test']).to.include('post');
+        const isValid = await Validate.test(response.result);
+        expect(isValid).to.be.true();
+      });
+    });
   });
 });

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -11,845 +11,892 @@ const Properties = require('../../lib/properties.js');
 const expect = Code.expect;
 const lab = (exports.lab = Lab.script());
 
-let definitionCollection;
-let propertiesAlt;
-let propertiesNoAlt;
-
-const clearDown = function () {
-  definitionCollection = {};
-  const altDefinitionCollection = {};
-
-  const definitionCache = [new WeakMap(), new WeakMap()];
-
-  propertiesAlt = new Properties(Defaults, definitionCollection, altDefinitionCollection, definitionCache);
-  const noAltSettings = Hoek.clone(Defaults);
-  noAltSettings.xProperties = false;
-  propertiesNoAlt = new Properties(noAltSettings, definitionCollection, altDefinitionCollection);
-};
-
 // parseProperty takes:   name, joiObj, parameterType, useDefinitions, isAlt
 // i.e. propertiesNoAlt.parseProperty('x', Joi.object(), null, true, false);
 // i.e. propertiesAlt.parseProperty('x', Joi.object(), null, true, true);
 
-lab.experiment('property - ', () => {
-  lab.test('parse types', () => {
-    clearDown();
-    expect(propertiesNoAlt.parseProperty('x', null, null, true, false)).to.equal(undefined);
-  });
+const versions = ['v2', 'v3.0'];
 
-  // parseProperty(name, joiObj, parent, parameterType, useDefinitions, isAlt)
+versions.forEach((version) => {
+  lab.experiment(`OAS ${version}`, () => {
+    let definitionCollection;
+    let propertiesAlt;
+    let propertiesNoAlt;
 
-  lab.test('parse types', () => {
-    clearDown();
-    //console.log(JSON.stringify(propertiesNoAlt.parseProperty('x', Joi.any(), null, null, true, false)));
-    expect(propertiesNoAlt.parseProperty('x', Joi.object(), null, 'body', true, false)).to.equal({
-      $ref: '#/definitions/x'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.string(), null, 'body', true, false)).to.equal({
-      type: 'string'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.number(), null, 'body', true, false)).to.equal({
-      type: 'number'
-    });
-    expect(
-      propertiesNoAlt.parseProperty('x', Joi.number().meta({ format: 'float' }), null, 'body', true, false)
-    ).to.equal({
-      type: 'number',
-      format: 'float'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.number().integer(), null, 'body', true, false)).to.equal({
-      type: 'integer'
-    });
-    expect(
-      propertiesNoAlt.parseProperty('x', Joi.number().integer().meta({ format: 'int64' }), null, 'body', true, false)
-    ).to.equal({
-      type: 'integer',
-      format: 'int64'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.boolean(), null, 'body', true, false)).to.equal({
-      type: 'boolean'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.date(), null, 'body', true, false)).to.equal({
-      type: 'string',
-      format: 'date'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.binary(), null, 'body', true, false)).to.equal({
-      type: 'string',
-      format: 'binary'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.array(), null, 'body', true, false)).to.equal({
-      $ref: '#/definitions/Model1'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.any(), null, 'body', true, false)).to.equal({ type: 'string' });
-    //expect(propertiesNoAlt.parseProperty('x', Joi.func(), null, 'body', true, false)).to.equal({ 'type': 'string' });
-  });
+    const clearDown = function () {
+      definitionCollection = {};
+      const altDefinitionCollection = {};
 
-  lab.test('parse types with useDefinitions=false', () => {
-    clearDown();
-    expect(propertiesNoAlt.parseProperty('x', Joi.object(), null, 'body', false, false)).to.equal({
-      type: 'object'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.string(), null, 'body', false, false)).to.equal({
-      type: 'string'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.number(), null, 'body', false, false)).to.equal({
-      type: 'number'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.boolean(), null, 'body', false, false)).to.equal({
-      type: 'boolean'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.date(), null, 'body', false, false)).to.equal({
-      type: 'string',
-      format: 'date'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.binary(), null, 'body', false, false)).to.equal({
-      type: 'string',
-      format: 'binary'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.array(), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'string' }
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.string().valid('a', 'b'), null, 'body', false, false)).to.equal({
-      type: 'string',
-      enum: ['a', 'b']
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.string().valid('a', 'b', ''), null, 'body', false, false)).to.equal({
-      type: 'string',
-      enum: ['a', 'b']
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.string().valid('a', 'b', null), null, 'body', false, false)).to.equal(
-      {
-        type: 'string',
-        enum: ['a', 'b']
-      }
-    );
-    expect(propertiesNoAlt.parseProperty('x', Joi.compile(['a', 'b', null]), null, 'body', false, false)).to.equal({
-      type: 'string',
-      enum: ['a', 'b']
-    });
-  });
+      const definitionCache = [new WeakMap(), new WeakMap()];
 
-  lab.test('parse simple meta', () => {
-    clearDown();
-    expect(
-      propertiesNoAlt.parseProperty('x', Joi.string().description('this is bob'), null, 'body', true, false)
-    ).to.equal({ type: 'string', description: 'this is bob' });
-    expect(propertiesAlt.parseProperty('x', Joi.string().example('bob'), null, 'body', true, false)).to.equal({
-      type: 'string',
-      example: 'bob'
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.allow('').example(''), null, 'body', true, false)).to.equal({
-      type: 'string',
-      example: ''
-    });
-  });
+      const baseSettings = { ...Defaults, OAS: version };
+      propertiesAlt = new Properties(baseSettings, definitionCollection, altDefinitionCollection, definitionCache);
+      const noAltSettings = Hoek.clone(baseSettings);
+      noAltSettings.xProperties = false;
+      propertiesNoAlt = new Properties(noAltSettings, definitionCollection, altDefinitionCollection);
+    };
 
-  lab.test('parse meta', () => {
-    clearDown();
-    // TODO add all meta data properties
-    expect(propertiesAlt.parseProperty('x', Joi.string().meta({ x: 'y' }), null, 'body', true, false)).to.equal({
-      type: 'string',
-      'x-meta': { x: 'y' }
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.string().forbidden(), null, 'body', true, false)).to.equal(undefined);
-    expect(propertiesNoAlt.parseProperty('x', Joi.string().required(), null, 'body', true, false)).to.equal({
-      type: 'string'
-    }); // required in parent
-    expect(propertiesNoAlt.parseProperty('x', Joi.any().required(), null, 'body', true, false)).to.equal({
-      type: 'string'
-    }); // required in parent
-    expect(propertiesNoAlt.parseProperty('x', Joi.any().forbidden(), null, 'body', true, false)).to.equal(undefined);
-    expect(propertiesNoAlt.parseProperty('x', Joi.string().valid('a', 'b'), null, 'body', true, false)).to.equal({
-      $ref: '#/definitions/x'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.string().valid('a', 'b', ''), null, 'body', true, false)).to.equal({
-      $ref: '#/definitions/x'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.string().valid('a', 'b', null), null, 'body', true, false)).to.equal({
-      $ref: '#/definitions/x'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.compile(['a', 'b', null]), null, 'body', true, false)).to.equal({
-      $ref: '#/definitions/x'
-    });
-    expect(
-      propertiesNoAlt.parseProperty(
-        'x',
-        Joi.date()
-          .timestamp()
-          .default(() => Date.now())
-      ).default
-    ).to.exist();
-    //console.log(JSON.stringify(propertiesAlt.parseProperty('x',Joi.date().timestamp().default(() => Date.now(), 'Current Timestamp'))));
+    lab.experiment('property - ', () => {
+      lab.test('parse types', () => {
+        clearDown();
+        expect(propertiesNoAlt.parseProperty('x', null, null, true, false)).to.equal(undefined);
+      });
 
-    const nonNegativeWithDropdown = propertiesAlt.parseProperty(
-      'x',
-      Joi.number().integer().positive().allow(0),
-      null,
-      'body',
-      true,
-      false
-    );
-    const nonNegativeWithoutDropdown = propertiesAlt.parseProperty(
-      'x',
-      Joi.number().integer().positive().allow(0).meta({ disableDropdown: true }),
-      null,
-      'body',
-      true,
-      false
-    );
+      // parseProperty(name, joiObj, parent, parameterType, useDefinitions, isAlt)
 
-    expect(nonNegativeWithDropdown).to.include({ enum: [0] });
-    expect(nonNegativeWithoutDropdown).to.not.include({ enum: [0] });
+      lab.test('parse types', () => {
+        clearDown();
+        //console.log(JSON.stringify(propertiesNoAlt.parseProperty('x', Joi.any(), null, null, true, false)));
+        expect(propertiesNoAlt.parseProperty('x', Joi.object(), null, 'body', true, false)).to.equal({
+          $ref: version === 'v2' ? '#/definitions/x' : '#/components/schemas/x'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.string(), null, 'body', true, false)).to.equal({
+          type: 'string'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.number(), null, 'body', true, false)).to.equal({
+          type: 'number'
+        });
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.number().meta({ format: 'float' }), null, 'body', true, false)
+        ).to.equal({
+          type: 'number',
+          format: 'float'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.number().integer(), null, 'body', true, false)).to.equal({
+          type: 'integer'
+        });
+        expect(
+          propertiesNoAlt.parseProperty(
+            'x',
+            Joi.number().integer().meta({ format: 'int64' }),
+            null,
+            'body',
+            true,
+            false
+          )
+        ).to.equal({
+          type: 'integer',
+          format: 'int64'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.boolean(), null, 'body', true, false)).to.equal({
+          type: 'boolean'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.date(), null, 'body', true, false)).to.equal({
+          type: 'string',
+          format: 'date'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.binary(), null, 'body', true, false)).to.equal({
+          type: 'string',
+          format: 'binary'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.array(), null, 'body', true, false)).to.equal({
+          $ref: version === 'v2' ? '#/definitions/Model1' : '#/components/schemas/Model1'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.any(), null, 'body', true, false)).to.equal({ type: 'string' });
+        //expect(propertiesNoAlt.parseProperty('x', Joi.func(), null, 'body', true, false)).to.equal({ 'type': 'string' });
+      });
 
-    const xmlObject = Joi.object().meta({ xml: { name: 'ObjectXML' } });
-    expect(propertiesAlt.parseProperty('x', xmlObject, null, 'body', false, false)).to.equal({
-      type: 'object',
-      xml: { name: 'ObjectXML' }
+      lab.test('parse types with useDefinitions=false', () => {
+        clearDown();
+        expect(propertiesNoAlt.parseProperty('x', Joi.object(), null, 'body', false, false)).to.equal({
+          type: 'object'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.string(), null, 'body', false, false)).to.equal({
+          type: 'string'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.number(), null, 'body', false, false)).to.equal({
+          type: 'number'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.boolean(), null, 'body', false, false)).to.equal({
+          type: 'boolean'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.date(), null, 'body', false, false)).to.equal({
+          type: 'string',
+          format: 'date'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.binary(), null, 'body', false, false)).to.equal({
+          type: 'string',
+          format: 'binary'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.array(), null, 'body', false, false)).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'string' }
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.string().valid('a', 'b'), null, 'body', false, false)).to.equal({
+          type: 'string',
+          enum: ['a', 'b']
+        });
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.string().valid('a', 'b', ''), null, 'body', false, false)
+        ).to.equal({
+          type: 'string',
+          enum: ['a', 'b']
+        });
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.string().valid('a', 'b', null), null, 'body', false, false)
+        ).to.equal({
+          type: 'string',
+          enum: ['a', 'b'],
+          ...(version === 'v2' ? {} : { nullable: true })
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.compile(['a', 'b', null]), null, 'body', false, false)).to.equal({
+          type: 'string',
+          enum: ['a', 'b'],
+          ...(version === 'v2' ? {} : { nullable: true })
+        });
+      });
+
+      lab.test('parse simple meta', () => {
+        clearDown();
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.string().description('this is bob'), null, 'body', true, false)
+        ).to.equal({ type: 'string', description: 'this is bob' });
+        expect(propertiesAlt.parseProperty('x', Joi.string().example('bob'), null, 'body', true, false)).to.equal({
+          type: 'string',
+          example: 'bob'
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.allow('').example(''), null, 'body', true, false)).to.equal({
+          type: 'string',
+          example: ''
+        });
+      });
+
+      lab.test('parse meta', () => {
+        clearDown();
+        // TODO add all meta data properties
+        expect(propertiesAlt.parseProperty('x', Joi.string().meta({ x: 'y' }), null, 'body', true, false)).to.equal({
+          type: 'string',
+          'x-meta': { x: 'y' }
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.string().forbidden(), null, 'body', true, false)).to.equal(
+          undefined
+        );
+        expect(propertiesNoAlt.parseProperty('x', Joi.string().required(), null, 'body', true, false)).to.equal({
+          type: 'string'
+        }); // required in parent
+        expect(propertiesNoAlt.parseProperty('x', Joi.any().required(), null, 'body', true, false)).to.equal({
+          type: 'string'
+        }); // required in parent
+        expect(propertiesNoAlt.parseProperty('x', Joi.any().forbidden(), null, 'body', true, false)).to.equal(
+          undefined
+        );
+        expect(propertiesNoAlt.parseProperty('x', Joi.string().valid('a', 'b'), null, 'body', true, false)).to.equal({
+          $ref: version === 'v2' ? '#/definitions/x' : '#/components/schemas/x'
+        });
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.string().valid('a', 'b', ''), null, 'body', true, false)
+        ).to.equal({
+          $ref: version === 'v2' ? '#/definitions/x' : '#/components/schemas/x'
+        });
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.string().valid('a', 'b', null), null, 'body', true, false)
+        ).to.equal({
+          $ref: version === 'v2' ? '#/definitions/x' : '#/components/schemas/Model1'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.compile(['a', 'b', null]), null, 'body', true, false)).to.equal({
+          $ref: version === 'v2' ? '#/definitions/x' : '#/components/schemas/Model2'
+        });
+        expect(
+          propertiesNoAlt.parseProperty(
+            'x',
+            Joi.date()
+              .timestamp()
+              .default(() => Date.now())
+          ).default
+        ).to.exist();
+        //console.log(JSON.stringify(propertiesAlt.parseProperty('x',Joi.date().timestamp().default(() => Date.now(), 'Current Timestamp'))));
+
+        const nonNegativeWithDropdown = propertiesAlt.parseProperty(
+          'x',
+          Joi.number().integer().positive().allow(0),
+          null,
+          'body',
+          true,
+          false
+        );
+        const nonNegativeWithoutDropdown = propertiesAlt.parseProperty(
+          'x',
+          Joi.number().integer().positive().allow(0).meta({ disableDropdown: true }),
+          null,
+          'body',
+          true,
+          false
+        );
+
+        expect(nonNegativeWithDropdown).to.include({ enum: [0] });
+        expect(nonNegativeWithoutDropdown).to.not.include({ enum: [0] });
+
+        const xmlObject = Joi.object().meta({ xml: { name: 'ObjectXML' } });
+        expect(propertiesAlt.parseProperty('x', xmlObject, null, 'body', false, false)).to.equal({
+          type: 'object',
+          xml: { name: 'ObjectXML' }
+        });
+
+        const xmlArrayOfObjects = Joi.array()
+          .items(xmlObject)
+          .meta({
+            xml: {
+              name: 'ArrayXML',
+              wrapped: true
+            }
+          });
+        expect(propertiesAlt.parseProperty('x', xmlArrayOfObjects, null, 'body', false, false)).to.equal({
+          type: 'array',
+          xml: { name: 'ArrayXML', wrapped: true },
+          items: {
+            type: 'object',
+            xml: { name: 'ObjectXML' }
+          },
+          name: 'x'
+        });
+      });
+
+      lab.test('parse hidden', () => {
+        expect(
+          propertiesAlt.parseProperty('x', Joi.string().meta({ swaggerHidden: true }), null, 'body', true, false)
+        ).to.equal(undefined);
+        expect(
+          propertiesAlt.parseProperty('x', Joi.string().meta({ swaggerHidden: false }), null, 'body', true, false)
+        ).to.equal({
+          type: 'string',
+          'x-meta': { swaggerHidden: false }
+        });
+      });
+
+      lab.test('parse type string', () => {
+        clearDown();
+        expect(propertiesNoAlt.parseProperty('x', Joi.string(), null, 'body', true, false)).to.equal({
+          type: 'string'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.string().min(5), null, 'body', true, false)).to.equal({
+          type: 'string',
+          minLength: 5
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.string().max(10), null, 'body', true, false)).to.equal({
+          type: 'string',
+          maxLength: 10
+        });
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.string().regex(/^[a-zA-Z0-9]{3,30}/), null, 'body', true, false)
+        ).to.equal({
+          type: 'string',
+          pattern: '^[a-zA-Z0-9]{3,30}'
+        });
+        // covers https://github.com/hapi-swagger/hapi-swagger/issues/652 -
+        // make sure we aren't truncating the regex after an internal '/',
+        // and make sure we omit any regex flags (g, i, m) from the
+        // resulting pattern
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.string().regex(/^https:\/\/test.com/im), null, 'body', true, false)
+        ).to.equal({
+          type: 'string',
+          pattern: '^https:\\/\\/test.com'
+        });
+
+        expect(propertiesAlt.parseProperty('x', Joi.string().length(0, 'utf8'), null, 'body', true, false)).to.equal({
+          type: 'string',
+          'x-constraint': { length: 0 }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.string().length(20, 'utf8'), null, 'body', true, false)).to.equal({
+          type: 'string',
+          'x-constraint': { length: 20 }
+        });
+        //expect(propertiesNoAlt.parseProperty('x', Joi.string().insensitive())).to.equal({ 'type': 'string', 'x-constraint': { 'insensitive': true } });
+
+        expect(propertiesAlt.parseProperty('x', Joi.string().creditCard(), null, 'body', true, false)).to.equal({
+          type: 'string',
+          'x-format': { creditCard: true }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.string().alphanum(), null, 'body', true, false)).to.equal({
+          type: 'string',
+          'x-format': { alphanum: true }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.string().token(), null, 'body', true, false)).to.equal({
+          type: 'string',
+          'x-format': { token: true }
+        });
+
+        const result = propertiesAlt.parseProperty(
+          'x',
+          Joi.string().email({
+            tlds: {
+              allow: ['com']
+            },
+            minDomainSegments: 2
+          }),
+          null,
+          true,
+          true
+        );
+
+        expect(result.type).to.equal('string');
+        expect(result['x-format'].email.tlds.allow).to.exist();
+        expect(result['x-format'].email.minDomainSegments).to.equal(2);
+
+        expect(
+          propertiesAlt.parseProperty(
+            'x',
+            Joi.string().ip({
+              version: ['ipv4', 'ipv6'],
+              cidr: 'required'
+            }),
+            null,
+            true,
+            true
+          )
+        ).to.equal({
+          type: 'string',
+          'x-format': {
+            ip: {
+              version: ['ipv4', 'ipv6'],
+              cidr: 'required'
+            }
+          }
+        });
+
+        /* TODO fix this so that regexp work or document the fact it does not work
+         expect(propertiesNoAlt.parseProperty('x', Joi.string().uri({
+             scheme: [
+                 'git',
+                 /git\+https?/
+             ]
+         }))).to.equal({ 'type': 'string', 'x-format': {
+             'uri': {
+                 'scheme': [
+                     'git',
+                     {}
+                 ]
+             }
+         } });
+         */
+
+        expect(propertiesAlt.parseProperty('x', Joi.string().guid(), null, 'body', true, true)).to.equal({
+          type: 'string',
+          'x-format': { guid: true }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.string().hex(), null, 'body', true, true)).to.equal({
+          type: 'string',
+          'x-format': { hex: { byteAligned: false } }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.string().guid(), null, 'body', true, true)).to.equal({
+          type: 'string',
+          'x-format': { guid: true }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.string().hostname(), null, 'body', true, true)).to.equal({
+          type: 'string',
+          'x-format': { hostname: true }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.string().isoDate(), null, 'body', true, true)).to.equal({
+          type: 'string',
+          'x-format': { isoDate: true }
+        });
+
+        expect(propertiesAlt.parseProperty('x', Joi.string().lowercase(), null, 'body', true, true)).to.equal({
+          type: 'string',
+          'x-convert': { case: 'lower' }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.string().uppercase(), null, 'body', true, true)).to.equal({
+          type: 'string',
+          'x-convert': { case: 'upper' }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.string().trim(), null, 'body', true, true)).to.equal({
+          type: 'string',
+          'x-convert': { trim: true }
+        });
+
+        // test options.xProperties = false
+        expect(propertiesNoAlt.parseProperty('x', Joi.string().lowercase(), null, 'body', true, false)).to.equal({
+          type: 'string'
+        });
+      });
+
+      lab.test('parse type date', () => {
+        clearDown();
+        expect(propertiesNoAlt.parseProperty('x', Joi.date(), null, 'body', true, false)).to.equal({
+          type: 'string',
+          format: 'date'
+        });
+
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().min('1-1-1974'), null, 'body', true, false)).to.equal({
+          type: 'string',
+          format: 'date'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().min('now'), null, 'body', true, false)).to.equal({
+          type: 'string',
+          format: 'date'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().min(Joi.ref('y')), null, 'body', true, false)).to.equal({
+          type: 'string',
+          format: 'date'
+        });
+
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().max('1-1-1974'), null, 'body', true, false)).to.equal({
+          type: 'string',
+          format: 'date'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().max('now'), null, 'body', true, false)).to.equal({
+          type: 'string',
+          format: 'date'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().max(Joi.ref('y')), null, 'body', true, false)).to.equal({
+          type: 'string',
+          format: 'date'
+        });
+
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.date().min('1-1-1974').max('now'), null, 'body', true, false)
+        ).to.equal({ type: 'string', format: 'date' });
+
+        /*  not yet 'x',
+          date.min(date)
+          date.max(date)
+          date.format(format)
+          date.iso()
+          */
+      });
+
+      lab.test('parse type date timestamp', () => {
+        clearDown();
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().timestamp(), null, 'body', true, false)).to.equal({
+          type: 'integer'
+        });
+      });
+
+      lab.test('parse type date iso', () => {
+        clearDown();
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().iso(), null, 'body', true, false)).to.equal({
+          type: 'string',
+          format: 'date-time'
+        });
+      });
+
+      lab.test('parse type number', () => {
+        clearDown();
+        // mapped direct to openapi
+        expect(propertiesNoAlt.parseProperty('x', Joi.number().integer(), null, 'body', true, false)).to.equal({
+          type: 'integer'
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.number().min(5), null, 'body', true, false)).to.equal({
+          type: 'number',
+          minimum: 5
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.number().max(10), null, 'body', true, false)).to.equal({
+          type: 'number',
+          maximum: 10
+        });
+
+        // x-* mappings
+        expect(propertiesAlt.parseProperty('x', Joi.number().greater(10), null, 'body', true, true)).to.equal({
+          type: 'number',
+          'x-constraint': { greater: 10 }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.number().less(10), null, 'body', true, true)).to.equal({
+          type: 'number',
+          'x-constraint': { less: 10 }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.number().precision(2), null, 'body', true, true)).to.equal({
+          type: 'number',
+          'x-constraint': { precision: 2 }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.number().multiple(2), null, 'body', true, true)).to.equal({
+          type: 'number',
+          'x-constraint': { multiple: 2 }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.number().positive(), null, 'body', true, true)).to.equal({
+          type: 'number',
+          'x-constraint': { sign: 'positive' }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.number().negative(), null, 'body', true, true)).to.equal({
+          type: 'number',
+          'x-constraint': { sign: 'negative' }
+        });
+
+        // test options.xProperties = false
+        expect(propertiesNoAlt.parseProperty('x', Joi.number().greater(10), null, 'body', true, false)).to.equal({
+          type: 'number'
+        });
+      });
+
+      lab.test('parse type array', () => {
+        clearDown();
+
+        //console.log(JSON.stringify(propertiesNoAlt.parseProperty('x', Joi.array(), null, false, false)));
+
+        // basic child types
+        expect(propertiesNoAlt.parseProperty('x', Joi.array(), null, 'body', false, false)).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'string' }
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.array().items(), null, 'body', false, false)).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'string' }
+        });
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.object()), null, 'body', false, false)
+        ).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'object' }
+        });
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.string()), null, 'body', false, false)
+        ).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'string' }
+        });
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.number()), null, 'body', false, false)
+        ).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'number' }
+        });
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.boolean()), null, 'body', false, false)
+        ).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'boolean' }
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.date()), null, 'body', false, false)).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'string', format: 'date' }
+        });
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.binary()), null, 'body', false, false)
+        ).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'string', format: 'binary' }
+        });
+
+        // complex child types - arrays and objects
+
+        clearDown();
+        //console.log(JSON.stringify(propertiesNoAlt.parseProperty('x', Joi.array().items({ 'text': Joi.string() }), null, 'formData', true, false)));
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.string()), null, 'formData', true, false)
+        ).to.equal({
+          $ref: version === 'v2' ? '#/definitions/x' : '#/components/schemas/x'
+        });
+        //console.log(JSON.stringify(definitionCollection));
+        expect(definitionCollection).to.equal(
+          version === 'v2'
+            ? {
+                x: {
+                  type: 'array',
+                  items: {
+                    type: 'string'
+                  },
+                  collectionFormat: 'multi'
+                }
+              }
+            : {
+                x: {
+                  type: 'array',
+                  items: {
+                    type: 'string'
+                  }
+                }
+              }
+        );
+
+        // TODO
+        // Joi.array().items(Joi.array().items(Joi.string())
+
+        // make sure type features such as string().min(1)in array items are past into JSON
+        expect(
+          propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.string().min(1)), null, 'body', false, false)
+        ).to.equal({ type: 'array', items: { type: 'string', minLength: 1 }, name: 'x' });
+
+        // mapped direct to openapi
+        expect(propertiesNoAlt.parseProperty('x', Joi.array().min(5), null, 'body', false, false)).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'string' },
+          minItems: 5
+        });
+        expect(propertiesNoAlt.parseProperty('x', Joi.array().max(10), null, 'body', false, false)).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'string' },
+          maxItems: 10
+        });
+
+        // x-* mappings
+        expect(propertiesAlt.parseProperty('x', Joi.array().sparse(), null, 'body', false, false)).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'string' },
+          'x-constraint': { sparse: true }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.array().single(), null, 'body', false, false)).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'string' },
+          'x-constraint': { single: true }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.array().length(0), null, 'body', false, false)).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'string' },
+          'x-constraint': { length: 0 }
+        });
+        expect(propertiesAlt.parseProperty('x', Joi.array().length(2), null, 'body', false, false)).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'string' },
+          'x-constraint': { length: 2 }
+        });
+
+        // https://github.com/hapijs/joi/pull/1511
+        expect(propertiesAlt.parseProperty('x', Joi.array().unique(), null, 'body', false, false)).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'string' },
+          'x-constraint': { unique: true }
+        });
+
+        // test options.xProperties = false
+        expect(propertiesNoAlt.parseProperty('x', Joi.array().sparse(), null, 'body', false, false)).to.equal({
+          type: 'array',
+          name: 'x',
+          items: { type: 'string' }
+        });
+      });
     });
 
-    const xmlArrayOfObjects = Joi.array()
-      .items(xmlObject)
-      .meta({
-        xml: {
-          name: 'ArrayXML',
-          wrapped: true
+    lab.test('parse type object', () => {
+      clearDown();
+      //console.log(JSON.stringify( propertiesNoAlt.parseProperty('x', Joi.object(), {}, {}, 'formData')  ));
+      expect(propertiesNoAlt.parseProperty('x', Joi.object(), null, 'body', false, false)).to.equal({ type: 'object' });
+      expect(propertiesNoAlt.parseProperty('x', Joi.object().keys(), null, 'body', false, false)).to.equal({
+        type: 'object'
+      });
+      expect(
+        propertiesNoAlt.parseProperty('x', Joi.object().keys({ a: Joi.string() }), null, 'body', false, false)
+      ).to.equal({
+        type: 'object',
+        properties: {
+          a: {
+            type: 'string'
+          }
         }
       });
-    expect(propertiesAlt.parseProperty('x', xmlArrayOfObjects, null, 'body', false, false)).to.equal({
-      type: 'array',
-      xml: { name: 'ArrayXML', wrapped: true },
-      items: {
+      expect(propertiesNoAlt.parseProperty('x', Joi.object({ a: Joi.string() }), null, 'body', false, false)).to.equal({
         type: 'object',
-        xml: { name: 'ObjectXML' }
-      },
-      name: 'x'
+        properties: {
+          a: {
+            type: 'string'
+          }
+        }
+      });
+      expect(propertiesNoAlt.parseProperty('x', Joi.object({ a: Joi.string() }), null, 'body', false, false)).to.equal({
+        type: 'object',
+        properties: {
+          a: {
+            type: 'string'
+          }
+        }
+      });
+      // test without pattern schema example
+      expect(
+        propertiesNoAlt.parseProperty(
+          'x',
+          Joi.object().pattern(
+            Joi.string(),
+            Joi.object({
+              y: Joi.string()
+            })
+          ),
+          null,
+          'body',
+          false,
+          false
+        )
+      ).to.equal({
+        type: 'object',
+        properties: {
+          string: {
+            type: 'object',
+            properties: {
+              y: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      });
+      // test with pattern schema example
+      expect(
+        propertiesNoAlt.parseProperty(
+          'x',
+          Joi.object().pattern(
+            Joi.string().example('a'),
+            Joi.object({
+              y: Joi.string()
+            })
+          ),
+          null,
+          'body',
+          false,
+          false
+        )
+      ).to.equal({
+        type: 'object',
+        properties: {
+          a: {
+            type: 'object',
+            properties: {
+              y: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      });
+      // test with regex as pattern
+      expect(
+        propertiesNoAlt.parseProperty(
+          'x',
+          Joi.object().pattern(
+            /\w\d/,
+            Joi.object({
+              y: Joi.string()
+            })
+          ),
+          null,
+          'body',
+          false,
+          false
+        )
+      ).to.equal({
+        type: 'object',
+        properties: {
+          string: {
+            type: 'object',
+            properties: {
+              y: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      });
     });
-  });
 
-  lab.test('parse hidden', () => {
-    expect(
-      propertiesAlt.parseProperty('x', Joi.string().meta({ swaggerHidden: true }), null, 'body', true, false)
-    ).to.equal(undefined);
-    expect(
-      propertiesAlt.parseProperty('x', Joi.string().meta({ swaggerHidden: false }), null, 'body', true, false)
-    ).to.equal({
-      type: 'string',
-      'x-meta': { swaggerHidden: false }
-    });
-  });
-
-  lab.test('parse type string', () => {
-    clearDown();
-    expect(propertiesNoAlt.parseProperty('x', Joi.string(), null, 'body', true, false)).to.equal({
-      type: 'string'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.string().min(5), null, 'body', true, false)).to.equal({
-      type: 'string',
-      minLength: 5
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.string().max(10), null, 'body', true, false)).to.equal({
-      type: 'string',
-      maxLength: 10
-    });
-    expect(
-      propertiesNoAlt.parseProperty('x', Joi.string().regex(/^[a-zA-Z0-9]{3,30}/), null, 'body', true, false)
-    ).to.equal({
-      type: 'string',
-      pattern: '^[a-zA-Z0-9]{3,30}'
-    });
-    // covers https://github.com/hapi-swagger/hapi-swagger/issues/652 -
-    // make sure we aren't truncating the regex after an internal '/',
-    // and make sure we omit any regex flags (g, i, m) from the
-    // resulting pattern
-    expect(
-      propertiesNoAlt.parseProperty('x', Joi.string().regex(/^https:\/\/test.com/im), null, 'body', true, false)
-    ).to.equal({
-      type: 'string',
-      pattern: '^https:\\/\\/test.com'
-    });
-
-    expect(propertiesAlt.parseProperty('x', Joi.string().length(0, 'utf8'), null, 'body', true, false)).to.equal({
-      type: 'string',
-      'x-constraint': { length: 0 }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.string().length(20, 'utf8'), null, 'body', true, false)).to.equal({
-      type: 'string',
-      'x-constraint': { length: 20 }
-    });
-    //expect(propertiesNoAlt.parseProperty('x', Joi.string().insensitive())).to.equal({ 'type': 'string', 'x-constraint': { 'insensitive': true } });
-
-    expect(propertiesAlt.parseProperty('x', Joi.string().creditCard(), null, 'body', true, false)).to.equal({
-      type: 'string',
-      'x-format': { creditCard: true }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.string().alphanum(), null, 'body', true, false)).to.equal({
-      type: 'string',
-      'x-format': { alphanum: true }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.string().token(), null, 'body', true, false)).to.equal({
-      type: 'string',
-      'x-format': { token: true }
-    });
-
-    const result = propertiesAlt.parseProperty(
-      'x',
-      Joi.string().email({
-        tlds: {
-          allow: ['com']
-        },
-        minDomainSegments: 2
-      }),
-      null,
-      true,
-      true
-    );
-
-    expect(result.type).to.equal('string');
-    expect(result['x-format'].email.tlds.allow).to.exist();
-    expect(result['x-format'].email.minDomainSegments).to.equal(2);
-
-    expect(
-      propertiesAlt.parseProperty(
-        'x',
-        Joi.string().ip({
-          version: ['ipv4', 'ipv6'],
-          cidr: 'required'
+    lab.experiment('property deep - ', () => {
+      clearDown();
+      const deepStructure = Joi.object({
+        outer1: Joi.object({
+          inner1: Joi.string()
+            .description('child description')
+            .note('child notes')
+            .tag('child', 'api')
+            .required()
+            .label('inner1')
         }),
-        null,
-        true,
-        true
-      )
-    ).to.equal({
-      type: 'string',
-      'x-format': {
-        ip: {
-          version: ['ipv4', 'ipv6'],
-          cidr: 'required'
-        }
-      }
-    });
-
-    /* TODO fix this so that regexp work or document the fact it does not work
-       expect(propertiesNoAlt.parseProperty('x', Joi.string().uri({
-           scheme: [
-               'git',
-               /git\+https?/
-           ]
-       }))).to.equal({ 'type': 'string', 'x-format': {
-           'uri': {
-               'scheme': [
-                   'git',
-                   {}
-               ]
-           }
-       } });
-       */
-
-    expect(propertiesAlt.parseProperty('x', Joi.string().guid(), null, 'body', true, true)).to.equal({
-      type: 'string',
-      'x-format': { guid: true }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.string().hex(), null, 'body', true, true)).to.equal({
-      type: 'string',
-      'x-format': { hex: { byteAligned: false } }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.string().guid(), null, 'body', true, true)).to.equal({
-      type: 'string',
-      'x-format': { guid: true }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.string().hostname(), null, 'body', true, true)).to.equal({
-      type: 'string',
-      'x-format': { hostname: true }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.string().isoDate(), null, 'body', true, true)).to.equal({
-      type: 'string',
-      'x-format': { isoDate: true }
-    });
-
-    expect(propertiesAlt.parseProperty('x', Joi.string().lowercase(), null, 'body', true, true)).to.equal({
-      type: 'string',
-      'x-convert': { case: 'lower' }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.string().uppercase(), null, 'body', true, true)).to.equal({
-      type: 'string',
-      'x-convert': { case: 'upper' }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.string().trim(), null, 'body', true, true)).to.equal({
-      type: 'string',
-      'x-convert': { trim: true }
-    });
-
-    // test options.xProperties = false
-    expect(propertiesNoAlt.parseProperty('x', Joi.string().lowercase(), null, 'body', true, false)).to.equal({
-      type: 'string'
-    });
-  });
-
-  lab.test('parse type date', () => {
-    clearDown();
-    expect(propertiesNoAlt.parseProperty('x', Joi.date(), null, 'body', true, false)).to.equal({
-      type: 'string',
-      format: 'date'
-    });
-
-    expect(propertiesNoAlt.parseProperty('x', Joi.date().min('1-1-1974'), null, 'body', true, false)).to.equal({
-      type: 'string',
-      format: 'date'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.date().min('now'), null, 'body', true, false)).to.equal({
-      type: 'string',
-      format: 'date'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.date().min(Joi.ref('y')), null, 'body', true, false)).to.equal({
-      type: 'string',
-      format: 'date'
-    });
-
-    expect(propertiesNoAlt.parseProperty('x', Joi.date().max('1-1-1974'), null, 'body', true, false)).to.equal({
-      type: 'string',
-      format: 'date'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.date().max('now'), null, 'body', true, false)).to.equal({
-      type: 'string',
-      format: 'date'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.date().max(Joi.ref('y')), null, 'body', true, false)).to.equal({
-      type: 'string',
-      format: 'date'
-    });
-
-    expect(
-      propertiesNoAlt.parseProperty('x', Joi.date().min('1-1-1974').max('now'), null, 'body', true, false)
-    ).to.equal({ type: 'string', format: 'date' });
-
-    /*  not yet 'x',
-        date.min(date)
-        date.max(date)
-        date.format(format)
-        date.iso()
-        */
-  });
-
-  lab.test('parse type date timestamp', () => {
-    clearDown();
-    expect(propertiesNoAlt.parseProperty('x', Joi.date().timestamp(), null, 'body', true, false)).to.equal({
-      type: 'integer'
-    });
-  });
-
-  lab.test('parse type date iso', () => {
-    clearDown();
-    expect(propertiesNoAlt.parseProperty('x', Joi.date().iso(), null, 'body', true, false)).to.equal({
-      type: 'string',
-      format: 'date-time'
-    });
-  });
-
-  lab.test('parse type number', () => {
-    clearDown();
-    // mapped direct to openapi
-    expect(propertiesNoAlt.parseProperty('x', Joi.number().integer(), null, 'body', true, false)).to.equal({
-      type: 'integer'
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.number().min(5), null, 'body', true, false)).to.equal({
-      type: 'number',
-      minimum: 5
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.number().max(10), null, 'body', true, false)).to.equal({
-      type: 'number',
-      maximum: 10
-    });
-
-    // x-* mappings
-    expect(propertiesAlt.parseProperty('x', Joi.number().greater(10), null, 'body', true, true)).to.equal({
-      type: 'number',
-      'x-constraint': { greater: 10 }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.number().less(10), null, 'body', true, true)).to.equal({
-      type: 'number',
-      'x-constraint': { less: 10 }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.number().precision(2), null, 'body', true, true)).to.equal({
-      type: 'number',
-      'x-constraint': { precision: 2 }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.number().multiple(2), null, 'body', true, true)).to.equal({
-      type: 'number',
-      'x-constraint': { multiple: 2 }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.number().positive(), null, 'body', true, true)).to.equal({
-      type: 'number',
-      'x-constraint': { sign: 'positive' }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.number().negative(), null, 'body', true, true)).to.equal({
-      type: 'number',
-      'x-constraint': { sign: 'negative' }
-    });
-
-    // test options.xProperties = false
-    expect(propertiesNoAlt.parseProperty('x', Joi.number().greater(10), null, 'body', true, false)).to.equal({
-      type: 'number'
-    });
-  });
-
-  lab.test('parse type array', () => {
-    clearDown();
-
-    //console.log(JSON.stringify(propertiesNoAlt.parseProperty('x', Joi.array(), null, false, false)));
-
-    // basic child types
-    expect(propertiesNoAlt.parseProperty('x', Joi.array(), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'string' }
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.array().items(), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'string' }
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.object()), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'object' }
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.string()), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'string' }
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.number()), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'number' }
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.boolean()), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'boolean' }
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.date()), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'string', format: 'date' }
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.binary()), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'string', format: 'binary' }
-    });
-
-    // complex child types - arrays and objects
-
-    clearDown();
-    //console.log(JSON.stringify(propertiesNoAlt.parseProperty('x', Joi.array().items({ 'text': Joi.string() }), null, 'formData', true, false)));
-    expect(propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.string()), null, 'formData', true, false)).to.equal(
-      {
-        $ref: '#/definitions/x'
-      }
-    );
-    //console.log(JSON.stringify(definitionCollection));
-    expect(definitionCollection).to.equal({
-      x: {
-        type: 'array',
-        items: {
-          type: 'string'
-        },
-        collectionFormat: 'multi'
-      }
-    });
-
-    // TODO
-    // Joi.array().items(Joi.array().items(Joi.string())
-
-    // make sure type features such as string().min(1)in array items are past into JSON
-    expect(
-      propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.string().min(1)), null, 'body', false, false)
-    ).to.equal({ type: 'array', items: { type: 'string', minLength: 1 }, name: 'x' });
-
-    // mapped direct to openapi
-    expect(propertiesNoAlt.parseProperty('x', Joi.array().min(5), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'string' },
-      minItems: 5
-    });
-    expect(propertiesNoAlt.parseProperty('x', Joi.array().max(10), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'string' },
-      maxItems: 10
-    });
-
-    // x-* mappings
-    expect(propertiesAlt.parseProperty('x', Joi.array().sparse(), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'string' },
-      'x-constraint': { sparse: true }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.array().single(), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'string' },
-      'x-constraint': { single: true }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.array().length(0), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'string' },
-      'x-constraint': { length: 0 }
-    });
-    expect(propertiesAlt.parseProperty('x', Joi.array().length(2), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'string' },
-      'x-constraint': { length: 2 }
-    });
-
-    // https://github.com/hapijs/joi/pull/1511
-    expect(propertiesAlt.parseProperty('x', Joi.array().unique(), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'string' },
-      'x-constraint': { unique: true }
-    });
-
-    // test options.xProperties = false
-    expect(propertiesNoAlt.parseProperty('x', Joi.array().sparse(), null, 'body', false, false)).to.equal({
-      type: 'array',
-      name: 'x',
-      items: { type: 'string' }
-    });
-  });
-});
-
-lab.test('parse type object', () => {
-  clearDown();
-  //console.log(JSON.stringify( propertiesNoAlt.parseProperty('x', Joi.object(), {}, {}, 'formData')  ));
-  expect(propertiesNoAlt.parseProperty('x', Joi.object(), null, 'body', false, false)).to.equal({ type: 'object' });
-  expect(propertiesNoAlt.parseProperty('x', Joi.object().keys(), null, 'body', false, false)).to.equal({
-    type: 'object'
-  });
-  expect(
-    propertiesNoAlt.parseProperty('x', Joi.object().keys({ a: Joi.string() }), null, 'body', false, false)
-  ).to.equal({
-    type: 'object',
-    properties: {
-      a: {
-        type: 'string'
-      }
-    }
-  });
-  expect(propertiesNoAlt.parseProperty('x', Joi.object({ a: Joi.string() }), null, 'body', false, false)).to.equal({
-    type: 'object',
-    properties: {
-      a: {
-        type: 'string'
-      }
-    }
-  });
-  expect(propertiesNoAlt.parseProperty('x', Joi.object({ a: Joi.string() }), null, 'body', false, false)).to.equal({
-    type: 'object',
-    properties: {
-      a: {
-        type: 'string'
-      }
-    }
-  });
-  // test without pattern schema example
-  expect(
-    propertiesNoAlt.parseProperty(
-      'x',
-      Joi.object().pattern(
-        Joi.string(),
-        Joi.object({
-          y: Joi.string()
+        outer2: Joi.object({
+          inner2: Joi.number()
+            .description('child description')
+            .note('child notes')
+            .tag('child', 'api')
+            .min(5)
+            .max(10)
+            .required()
+            .label('inner2')
         })
-      ),
-      null,
-      'body',
-      false,
-      false
-    )
-  ).to.equal({
-    type: 'object',
-    properties: {
-      string: {
-        type: 'object',
-        properties: {
-          y: {
-            type: 'string'
-          }
-        }
-      }
-    }
-  });
-  // test with pattern schema example
-  expect(
-    propertiesNoAlt.parseProperty(
-      'x',
-      Joi.object().pattern(
-        Joi.string().example('a'),
-        Joi.object({
-          y: Joi.string()
-        })
-      ),
-      null,
-      'body',
-      false,
-      false
-    )
-  ).to.equal({
-    type: 'object',
-    properties: {
-      a: {
-        type: 'object',
-        properties: {
-          y: {
-            type: 'string'
-          }
-        }
-      }
-    }
-  });
-  // test with regex as pattern
-  expect(
-    propertiesNoAlt.parseProperty(
-      'x',
-      Joi.object().pattern(
-        /\w\d/,
-        Joi.object({
-          y: Joi.string()
-        })
-      ),
-      null,
-      'body',
-      false,
-      false
-    )
-  ).to.equal({
-    type: 'object',
-    properties: {
-      string: {
-        type: 'object',
-        properties: {
-          y: {
-            type: 'string'
-          }
-        }
-      }
-    }
-  });
-});
+      });
 
-lab.experiment('property deep - ', () => {
-  clearDown();
-  const deepStructure = Joi.object({
-    outer1: Joi.object({
-      inner1: Joi.string()
-        .description('child description')
-        .note('child notes')
-        .tag('child', 'api')
-        .required()
-        .label('inner1')
-    }),
-    outer2: Joi.object({
-      inner2: Joi.number()
-        .description('child description')
-        .note('child notes')
-        .tag('child', 'api')
-        .min(5)
-        .max(10)
-        .required()
-        .label('inner2')
-    })
-  });
+      //console.log(JSON.stringify( propertiesNoAlt.parseProperty( deepStructure, {}, {}, null, false ) ));
 
-  //console.log(JSON.stringify( propertiesNoAlt.parseProperty( deepStructure, {}, {}, null, false ) ));
+      lab.test('parse structure with child labels', () => {
+        //console.log(JSON.stringify( propertiesNoAlt.parseProperty(null, deepStructure, null, false, false)  ));
 
-  lab.test('parse structure with child labels', () => {
-    //console.log(JSON.stringify( propertiesNoAlt.parseProperty(null, deepStructure, null, false, false)  ));
-
-    expect(propertiesNoAlt.parseProperty(null, deepStructure, null, 'body', false, false)).to.equal({
-      type: 'object',
-      properties: {
-        outer1: {
+        expect(propertiesNoAlt.parseProperty(null, deepStructure, null, 'body', false, false)).to.equal({
           type: 'object',
           properties: {
+            outer1: {
+              type: 'object',
+              properties: {
+                inner1: {
+                  type: 'string',
+                  description: 'child description',
+                  notes: ['child notes'],
+                  tags: ['child', 'api']
+                }
+              },
+              required: ['inner1']
+            },
+            outer2: {
+              type: 'object',
+              properties: {
+                inner2: {
+                  type: 'number',
+                  description: 'child description',
+                  notes: ['child notes'],
+                  tags: ['child', 'api'],
+                  minimum: 5,
+                  maximum: 10
+                }
+              },
+              required: ['inner2']
+            }
+          }
+        });
+      });
+
+      lab.test('parse structure with child description, notes, name etc', async () => {
+        clearDown();
+        const routes = [
+          {
+            method: 'POST',
+            path: '/path/two',
+            options: {
+              tags: ['api'],
+              handler: Helper.defaultHandler,
+              response: {
+                schema: deepStructure
+              }
+            }
+          }
+        ];
+
+        const server = await Helper.createServer({}, routes);
+        const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+
+        //console.log(JSON.stringify(response.result.definitions));
+        expect(response.result.definitions.outer1).to.equal({
+          properties: {
             inner1: {
-              type: 'string',
               description: 'child description',
+              type: 'string',
               notes: ['child notes'],
               tags: ['child', 'api']
             }
           },
-          required: ['inner1']
-        },
-        outer2: {
-          type: 'object',
-          properties: {
-            inner2: {
-              type: 'number',
-              description: 'child description',
-              notes: ['child notes'],
-              tags: ['child', 'api'],
-              minimum: 5,
-              maximum: 10
-            }
-          },
-          required: ['inner2']
-        }
-      }
+          required: ['inner1'],
+          type: 'object'
+        });
+      });
     });
-  });
 
-  lab.test('parse structure with child description, notes, name etc', async () => {
-    clearDown();
-    const routes = [
-      {
-        method: 'POST',
-        path: '/path/two',
-        options: {
-          tags: ['api'],
-          handler: Helper.defaultHandler,
-          response: {
-            schema: deepStructure
-          }
-        }
-      }
-    ];
-
-    const server = await Helper.createServer({}, routes);
-    const response = await server.inject({ method: 'GET', url: '/swagger.json' });
-
-    //console.log(JSON.stringify(response.result.definitions));
-    expect(response.result.definitions.outer1).to.equal({
-      properties: {
-        inner1: {
-          description: 'child description',
-          type: 'string',
-          notes: ['child notes'],
-          tags: ['child', 'api']
-        }
-      },
-      required: ['inner1'],
-      type: 'object'
-    });
-  });
-});
-
-lab.experiment('joi extension - ', () => {
-  lab.test('custom joi extension', () => {
-    clearDown();
-    const extension = Joi.extend({
-      base: Joi.string(),
-      type: 'myCustomName'
-    });
-    expect(propertiesNoAlt.parseProperty('x', extension.myCustomName(), null, 'body', true, false)).to.equal({
-      type: 'string'
+    lab.experiment('joi extension - ', () => {
+      lab.test('custom joi extension', () => {
+        clearDown();
+        const extension = Joi.extend({
+          base: Joi.string(),
+          type: 'myCustomName'
+        });
+        expect(propertiesNoAlt.parseProperty('x', extension.myCustomName(), null, 'body', true, false)).to.equal({
+          type: 'string'
+        });
+      });
     });
   });
 });

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -15,18 +15,16 @@ let definitionCollection;
 let propertiesAlt;
 let propertiesNoAlt;
 
-const clearDown = function() {
+const clearDown = function () {
   definitionCollection = {};
   const altDefinitionCollection = {};
 
   const definitionCache = [new WeakMap(), new WeakMap()];
 
   propertiesAlt = new Properties(Defaults, definitionCollection, altDefinitionCollection, definitionCache);
-  propertiesNoAlt = new Properties(
-    (Hoek.clone(Defaults).xProperties = false),
-    definitionCollection,
-    altDefinitionCollection
-  );
+  const noAltSettings = Hoek.clone(Defaults);
+  noAltSettings.xProperties = false;
+  propertiesNoAlt = new Properties(noAltSettings, definitionCollection, altDefinitionCollection);
 };
 
 // parseProperty takes:   name, joiObj, parameterType, useDefinitions, isAlt
@@ -53,14 +51,18 @@ lab.experiment('property - ', () => {
     expect(propertiesNoAlt.parseProperty('x', Joi.number(), null, 'body', true, false)).to.equal({
       type: 'number'
     });
-    expect(propertiesNoAlt.parseProperty('x', Joi.number().meta({ format: 'float' }), null, 'body', true, false)).to.equal({
+    expect(
+      propertiesNoAlt.parseProperty('x', Joi.number().meta({ format: 'float' }), null, 'body', true, false)
+    ).to.equal({
       type: 'number',
       format: 'float'
     });
     expect(propertiesNoAlt.parseProperty('x', Joi.number().integer(), null, 'body', true, false)).to.equal({
       type: 'integer'
     });
-    expect(propertiesNoAlt.parseProperty('x', Joi.number().integer().meta({ format: 'int64' }), null, 'body', true, false)).to.equal({
+    expect(
+      propertiesNoAlt.parseProperty('x', Joi.number().integer().meta({ format: 'int64' }), null, 'body', true, false)
+    ).to.equal({
       type: 'integer',
       format: 'int64'
     });
@@ -183,10 +185,7 @@ lab.experiment('property - ', () => {
 
     const nonNegativeWithDropdown = propertiesAlt.parseProperty(
       'x',
-      Joi.number()
-        .integer()
-        .positive()
-        .allow(0),
+      Joi.number().integer().positive().allow(0),
       null,
       'body',
       true,
@@ -194,11 +193,7 @@ lab.experiment('property - ', () => {
     );
     const nonNegativeWithoutDropdown = propertiesAlt.parseProperty(
       'x',
-      Joi.number()
-        .integer()
-        .positive()
-        .allow(0)
-        .meta({ disableDropdown: true }),
+      Joi.number().integer().positive().allow(0).meta({ disableDropdown: true }),
       null,
       'body',
       true,
@@ -426,16 +421,7 @@ lab.experiment('property - ', () => {
     });
 
     expect(
-      propertiesNoAlt.parseProperty(
-        'x',
-        Joi.date()
-          .min('1-1-1974')
-          .max('now'),
-        null,
-        'body',
-        true,
-        false
-      )
+      propertiesNoAlt.parseProperty('x', Joi.date().min('1-1-1974').max('now'), null, 'body', true, false)
     ).to.equal({ type: 'string', format: 'date' });
 
     /*  not yet 'x',

--- a/usageguide.md
+++ b/usageguide.md
@@ -126,10 +126,10 @@ validate: {
 }
 ```
 
-**NOTE: the plugin reuses "definition models" these describe each JSON object use by an API i.e. a "user". This feature
-was added to reduce the size of the JSON. The plugin can reuse the model only if the labels match. Even if two routes have the same definition, but labels are not set, the plugin assumes that it is a different definition, the same if one definition has a label and another does not. 
+\*\*NOTE: the plugin reuses "definition models" these describe each JSON object use by an API i.e. a "user". This feature
+was added to reduce the size of the JSON. The plugin can reuse the model only if the labels match. Even if two routes have the same definition, but labels are not set, the plugin assumes that it is a different definition, the same if one definition has a label and another does not.
 
-By default, objects are named in a "Model #" format. To use the `label`, specify `options.definitionPrefix` as `useLabel`.**
+By default, objects are named in a "Model #" format. To use the `label`, specify `options.definitionPrefix` as `useLabel`.\*\*
 
 ## Grouping endpoints by path or tags
 
@@ -619,7 +619,7 @@ Not all the flexibility of Hapi and JOI can to ported over to the Swagger schema
 -   **`array.ordered(type)`** This allows for different typed items within an array. i.e. string or int.
 -   **`{name*}`** The path parameters with the `*` char are not supported, either is the `{name*3}` the pattern. This will mostly likely be added to the next version of OpenAPI spec.
 -   **`.allow( null )`** The current Swagger spec does not support `null`. This **maybe** added to the next version of OpenAPI spec.
--   **`payload: function (value, options, next) {next(null, value);}`** The use of custom functions to validate pramaters is not support beyond replacing them with an emtpy model call "Hidden Model".
+-   **`payload: function (value, options, next) {next(null, value);}`** The use of custom functions to validate pramaters is not support beyond replacing them with an empty model call "Hidden Model".
 -   **`Joi.date().format('yy-mm-dd')` ** The use of a `moment` pattern to format a date cannot be reproduced in Swagger
 -   **`Joi.date().min()` and `Joi.date().max()`** Minimum or maximum dates cannot be expressed in Swagger.
 


### PR DESCRIPTION
Hi,

I've implemented basic OpenAPI v3.0 spec output with the additional support for `anyOf` and `nullable` in JSON schemas.

I started without knowing Swagger 2.0, OpenAPI 3.0, or this module at all, so there may be mistakes, but it seems to pass validators. I'm pretty sure I didn't implement the full spec, but it seems to work on all the test servers and on our own real-world server, so I think it's already a good starting point.

I tried to reuse most of the existing code whenever possible, but working with the code base seemed a bit tedious at the end. I feel like this may need a deeper rewrite, but I didn't have the resources nor did I feel entitled to do that in a feature PR, so I hope the way I did it won't bother you too much. Tests are sometimes adapted, sometimes full copies of existing ones with the 3.0 twist when it would introduce too many conditionals, it feels more maintainable that way, but one has to implement new tests in both files in the future, unfortunately. This may be possible with a lot of abstracted test helpers.