### PR TITLE
Add 'unsorted' option for sortTags and sortEndpoints

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,9 +51,9 @@ declare namespace hapiswagger {
 
   type ExpandedType = 'none' | 'list' | 'full';
 
-  type SortTagsType = 'alpha';
+  type SortTagsType = 'alpha' | 'unsorted';
 
-  type SortEndpointsType = 'alpha' | 'method' | 'ordered';
+  type SortEndpointsType = 'alpha' | 'method' | 'ordered' | 'unsorted';
 
   type UiCompleteScriptObjectType = {
     src: string;
@@ -437,13 +437,13 @@ declare namespace hapiswagger {
     expanded?: ExpandedType;
 
     /**
-     * Sort method for `tags` i.e. groups in UI.
+     * Sort method for `tags` i.e. groups in UI. Values include `alpha`, `unsorted`.
      * @default: 'alpha'
      */
     sortTags?: SortTagsType;
 
     /**
-     * Sort method for endpoints in UI. Values include `alpha`, `method`, `ordered`.
+     * Sort method for endpoints in UI. Values include `alpha`, `method`, `ordered`, `unsorted`.
      * @default: 'alpha'
      */
     sortEndpoints?: SortEndpointsType;

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,8 +28,8 @@ const schema = Joi.object({
   documentationPage: Joi.boolean(),
   swaggerUI: Joi.boolean(),
   expanded: Joi.string().valid('none', 'list', 'full'),
-  sortTags: Joi.string().valid('alpha'),
-  sortEndpoints: Joi.string().valid('alpha', 'method', 'ordered'),
+  sortTags: Joi.string().valid('alpha', 'unsorted'),
+  sortEndpoints: Joi.string().valid('alpha', 'method', 'ordered', 'unsorted'),
   sortPaths: Joi.string().valid('unsorted', 'path-method'),
 
   // patch: uiCompleteScript -- Define validation scope

--- a/optionsreference.md
+++ b/optionsreference.md
@@ -61,12 +61,14 @@
 -   `documentationPath`: (string) The path of the documentation page - default: `/documentation`
 -   `templates`: (string) The directory path used by `hapi-swagger` and `@hapi/vision` to resolve and load the templates to render `swagger-ui` interface. The directory must contain `index.html` and `debug.html` templates. Default is `templates` directory in this package.
 -   `expanded`: (string) If UI is expanded when opened. `none`, `list` or `full` - default: `list`
--   `sortTags`: (string) a sort method for `tags` i.e. groups in UI. `alpha`
+-   `sortTags`: (string) a sort method for `tags` i.e. groups in UI. Default is `alpha`.
     -   `alpha`: sort by paths alphanumerically
--   `sortEndpoints`: (string) a sort method for endpoints in UI. `alpha`, `method`, `ordered`. Default is `alpha`.
+    -   `unsorted`: leave tags unsorted. If `tags` is used they will be in the order defined there.
+-   `sortEndpoints`: (string) a sort method for endpoints in UI. `alpha`, `method`, `ordered`, `unsorted`. Default is `alpha`.
     -   `alpha`: sort by paths alphanumerically
     -   `method`: sort by HTTP method
     -   `ordered`: sort by `order` value of the `hapi-swagger` plugin options of the route.
+    -   `unsorted`: leave endpoints unsorted
 -   `uiCompleteScript`: (string || object) Called when UI loads. Can be javascript string injected into the HTML (ex: `'alert("I got you !")'`) or object with `src` property (ex: `{ src: '/assets/js/doc-patch.js' }`) that can point to reference remote file. The file will be loaded on demand and appended to DOM. Default is `null`.
 -   `validatorUrl`: (string || null) sets the external validating URL Can switch off by setting to `null`
 -   `tryItOutEnabled`: (boolean) controls whether the "Try it out" section should be enabled by default - default: `false`

--- a/public/extend.js
+++ b/public/extend.js
@@ -1,10 +1,12 @@
 // sort function for tag groups
 var apisSorter = {
+  unsorted: null,
   alpha: 'alpha'
 };
 
 // sort function for api endpoints within groups
 var operationsSorter = {
+  unsorted: null,
   alpha: 'alpha',
   method: 'method',
   ordered: function(a, b) {

--- a/usageguide.md
+++ b/usageguide.md
@@ -214,14 +214,15 @@ const options = {
 };
 ```
 
-The groups are order in the same sequence you add them to the `tags` array in the plug-in options. You can enforce
-the order by name A-Z by switching the plugin `options.sortTags = 'name'`.
+In the schema tags are ordered in the same sequence you add them to the `tags` array in the plugin options.
+In the UI groups are sorted alphabetically by default. To have them ordered in the sequence defined in `tags` set
+the plugin option `sortTags = 'unsorted'`.
 
 ## Ordering the endpoints within groups
 
-The endpoints within the UI groups can be order with the property `options.sortEndpoints`, by default the are ordered
-A-Z using the `alpha` (path) information. Can also order them by `method`. Finally if you wish to enforce you own order then
-you added route option `order` to each endpoint and switch the plugin options to `options.sortEndpoints = 'ordered'`.
+The endpoints within the UI groups can be ordered with the property `options.sortEndpoints`, by default they are ordered
+A-Z using the `alpha` (path) information. You can also order them by `method`. Finally if you wish to enforce your own order
+then add the route option `order` to each endpoint and switch the plugin option `sortEndpoints = 'ordered'`.
 
 ```javascript
 {


### PR DESCRIPTION
This PR adds an `unsorted` value for both `options.sortTags` and `options.sortEndpoints` which disables explicit sorting of tags and endpoints by the swagger UI.

This change is needed to be able to define the order of the tag groups in the UI via `options.tags`. While the documentation claimed that was the default behavior, groups were actually always sorted alphabetically without any way to change their order.