### PR TITLE
Add uiOptions setting to pass arbitrary options to Swagger UI

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -455,6 +455,12 @@ declare namespace hapiswagger {
     uiCompleteScript?: UiCompleteScriptType;
 
     /**
+     * An object of options to be passed to Swagger UI.
+     * @default {}
+     */
+    uiOptions?: object;
+
+    /**
      * Sets the external validating URL Can switch off by setting to `null`
      * @default 'https://online.swagger.io/validator'
      */

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -245,6 +245,7 @@ internals.removeNoneSchemaOptions = function(options) {
     'xProperties',
     'reuseDefinitions',
     'uiCompleteScript',
+    'uiOptions',
     'deReference',
     'definitionPrefix',
     'validatorUrl',

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -23,6 +23,7 @@ module.exports = {
   grouping: 'path',
   tagsGroupingFilter: tag => tag !== 'api',
   uiCompleteScript: null,
+  uiOptions: {},
   xProperties: true,
   reuseDefinitions: true,
   wildcardMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,7 @@ const schema = Joi.object({
         src: Joi.string().required()
       })
   ).allow(null),
+  uiOptions: Joi.object().default({}),
   xProperties: Joi.boolean(),
   reuseDefinitions: Joi.boolean(),
   wildcardMethods: Joi.array().items(Joi.string().not('HEAD', 'OPTIONS')),  // OPTIONS not supported by Swagger and HEAD not support by Hapi
@@ -185,12 +186,15 @@ exports.plugin = {
     if (settings.documentationPage === true || settings.swaggerUI === true) {
       server.dependency(['@hapi/inert', '@hapi/vision'], server => {
         // Setup vision using handlebars from the templates directory
-        server.views({
+        const manager = server.views({
           engines: {
             html: require('handlebars')
           },
           path: settings.templates
         });
+
+        // Register a helper we can use in template to render a context value as JSON.
+        manager.registerHelper('toJSON', (obj) => JSON.stringify(obj));
 
         // add documentation page
         if (settings.documentationPage === true) {

--- a/optionsreference.md
+++ b/optionsreference.md
@@ -68,6 +68,7 @@
     -   `method`: sort by HTTP method
     -   `ordered`: sort by `order` value of the `hapi-swagger` plugin options of the route.
 -   `uiCompleteScript`: (string || object) Called when UI loads. Can be javascript string injected into the HTML (ex: `'alert("I got you !")'`) or object with `src` property (ex: `{ src: '/assets/js/doc-patch.js' }`) that can point to reference remote file. The file will be loaded on demand and appended to DOM. Default is `null`.
+-   `uiOptions`: (object) Configuration [options](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/) which are passed to Swagger UI.
 -   `validatorUrl`: (string || null) sets the external validating URL Can switch off by setting to `null`
 -   `tryItOutEnabled`: (boolean) controls whether the "Try it out" section should be enabled by default - default: `false`
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,6 +81,9 @@
           tryItOutEnabled: {{hapiSwagger.tryItOutEnabled}},
         }
 
+        const uiOptions = {{{toJSON hapiSwagger.uiOptions}}};
+        Object.assign(swaggerOptions, uiOptions);
+
         const ui = SwaggerUIBundle(swaggerOptions);
 
         window.ui = ui;


### PR DESCRIPTION
There are quite a few Swagger UI settings which someone using hapi-swagger might want to change. Instead of adding them all as plugin options this PR adds a single `uiOptions` setting which can be an object of arbitrary options passed to Swagger UI.