### PR TITLE
Add title to property based on Joi meta property

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -311,6 +311,7 @@ internals.properties.prototype.parsePropertyMetadata = function (property, name,
   property.description = Hoek.reach(joiObj, '_flags.description');
   property.notes = Hoek.reach(joiObj, '$_terms.notes');
   property.tags = Hoek.reach(joiObj, '$_terms.tags');
+  property.title = Utilities.getJoiMetaProperty(joiObj, 'title');
 
   // add extended properties not part of openAPI spec
   if (this.settings.xProperties === true) {

--- a/test/Integration/alternatives-test.js
+++ b/test/Integration/alternatives-test.js
@@ -16,7 +16,9 @@ lab.experiment('alternatives', () => {
         handler: Helper.defaultHandler,
         tags: ['api'],
         validate: {
-          payload: Joi.alternatives().try(Joi.number(), Joi.string()).label('Alt')
+          payload: Joi.alternatives()
+            .try(Joi.number().meta({ title: 'a number' }), Joi.string().meta({ title: 'a string' }))
+            .label('Alt')
         }
       }
     },
@@ -157,12 +159,23 @@ lab.experiment('alternatives', () => {
         },
         'x-alternatives': [
           {
-            type: 'number'
+            'x-meta': {
+              title: 'a number'
+            },
+            type: 'number',
+            title: 'a number'
           },
           {
-            type: 'string'
+            'x-meta': {
+              title: 'a string'
+            },
+            type: 'string',
+            title: 'a string'
           }
         ],
+        'x-meta': {
+          title: 'a number'
+        },
         name: 'body'
       }
     ]);
@@ -379,7 +392,16 @@ lab.experiment('alternatives', () => {
       content: {
         'application/json': {
           schema: {
-            anyOf: [{ type: 'number' }, { type: 'string' }]
+            anyOf: [
+              {
+                type: 'number',
+                'x-meta': {
+                  title: 'a number'
+                },
+                title: 'a number'
+              },
+              { type: 'string', 'x-meta': { title: 'a string' }, title: 'a string' }
+            ]
           }
         }
       }

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -696,15 +696,23 @@ versions.forEach((version) => {
           }
         }
       });
-      expect(propertiesNoAlt.parseProperty('x', Joi.object(
-        { 
-          a: Joi.string(),
-          b: Joi.string().when('a', {
-            is: 'any',
-            then: Joi.string().required(),
-            otherwise: Joi.string().optional(),
+      expect(
+        propertiesNoAlt.parseProperty(
+          'x',
+          Joi.object({
+            a: Joi.string(),
+            b: Joi.string().when('a', {
+              is: 'any',
+              then: Joi.string().required(),
+              otherwise: Joi.string().optional()
+            })
           }),
-        }), null, 'body', false, false)).to.equal({
+          null,
+          'body',
+          false,
+          false
+        )
+      ).to.equal({
         type: 'object',
         properties: {
           a: {
@@ -714,9 +722,7 @@ versions.forEach((version) => {
             type: 'string'
           }
         },
-        required: [
-          'b'
-        ]
+        required: ['b']
       });
       expect(propertiesNoAlt.parseProperty('x', Joi.object({ a: Joi.string() }), null, 'body', false, false)).to.equal({
         type: 'object',
@@ -822,6 +828,7 @@ versions.forEach((version) => {
             .tag('child', 'api')
             .required()
             .label('inner1')
+            .meta({ title: 'child title' })
         }),
         outer2: Joi.object({
           inner2: Joi.number()
@@ -850,7 +857,8 @@ versions.forEach((version) => {
                   type: 'string',
                   description: 'child description',
                   notes: ['child notes'],
-                  tags: ['child', 'api']
+                  tags: ['child', 'api'],
+                  title: 'child title'
                 }
               },
               required: ['inner1']
@@ -896,10 +904,14 @@ versions.forEach((version) => {
         expect(response.result.definitions.outer1).to.equal({
           properties: {
             inner1: {
+              'x-meta': {
+                title: 'child title'
+              },
               description: 'child description',
               type: 'string',
               notes: ['child notes'],
-              tags: ['child', 'api']
+              tags: ['child', 'api'],
+              title: 'child title'
             }
           },
           required: ['inner1'],


### PR DESCRIPTION
The thing that led to this PR is the OpenAPI v3 AnyOf generation. In Redocly (which we use) at least this shows the type ('object', 'string', 'number') on the alternatives-selector by default.

![image](https://github.com/hapi-swagger/hapi-swagger/assets/2349560/45f857c7-a2c1-49e5-a583-db7b7af88c63)

To show a more descriptive label you can add the `title` property to each of the alternatives, which gets you something like this:

![image](https://github.com/hapi-swagger/hapi-swagger/assets/2349560/3ca32c4a-2091-463c-8b0d-128346e957d0)

This PR adds support for the `title`-property to hapi-swagger through the `title` Joi.meta() property.

```typescript
joiModel.meta({ title: 'SIF' })
```

I've added it very generically, as this property can be added to any schema in both OpenAPI 2 & 3, and display after the property type in Redocly:

```typescript
status: Joi.string().meta({ title: 'QuotationStatus' }),
```

![image](https://github.com/hapi-swagger/hapi-swagger/assets/2349560/d0a42af9-02fd-431e-aebd-0523221c4b06)

It was deceptively simple to add, so please let me know if I missed any edge-cases, added it to the wrong tests or did something else stupid :)

I did not check how this affects SwaggerUI display, but it seems that such an integral part of the OpenAPI def should just work :)

The meta property name `title` may be too generic, we could change it to `swaggerTitle` I guess.