### PR TITLE
Fixed problem with "deReference" on openapi v3.

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -181,7 +181,13 @@ builder.getSwaggerJSON = async (settings, request) => {
 builder.dereference = async (schema) => {
   try {
     const json = await JSONDeRef.dereference(schema);
-    delete json.definitions;
+
+    if (schema.openapi === '3.0.0') {
+      delete json.components;
+    } else {
+      delete json.definitions;
+    }
+
     delete json['x-alt-definitions'];
     return json;
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hapi-swagger",
   "description": "A swagger documentation UI generator plugin for hapi",
-  "version": "17.2.0",
+  "version": "17.2.1",
   "author": "Glenn Jones",
   "repository": {
     "type": "git",

--- a/test/Integration/dereference-test.js
+++ b/test/Integration/dereference-test.js
@@ -59,6 +59,36 @@ lab.experiment('dereference', () => {
     expect(isValid).to.be.true();
   });
 
+  lab.test('flatten with no references on OAS v3', async () => {
+    const server = await Helper.createServer({ deReference: true, OAS: 'v3.0' }, routes);
+    const response = await server.inject({ method: 'GET', url: '/openapi.json' });
+    expect(response.result.components).not.exists();
+    expect(response.statusCode).to.equal(200);
+    expect(response.result.paths['/store/'].post.requestBody.content).to.equal({
+      "application/json": {
+        schema: {
+          properties: {
+            a: {
+              type: 'number'
+            },
+            b: {
+              type: 'number'
+            },
+            operator: {
+              type: 'string'
+            },
+            equals: {
+              type: 'number'
+            }
+          },
+          type: 'object'
+        }
+      }
+    });
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
   lab.test('flatten with no references (OpenAPI)', async () => {
     const server = await Helper.createServer({ OAS: 'v3.0', deReference: true }, routes);
     const response = await server.inject({ method: 'GET', url: '/openapi.json' });


### PR DESCRIPTION
Method "deRefrence" does not clear the schema for openapi version 3.