### PR TITLE
Better handling of alternatives for openapi v3

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -611,7 +611,9 @@ internals.properties.prototype.parseAlternatives = function (property, joiObj, n
         property['x-alternatives'] = Hoek.clone(altArray);
       }
     } else {
-      property.anyOf = buildAlternativesArray(joiObj.$_terms.matches.map((obj) => obj.schema));
+      property.anyOf = joiObj.$_terms.matches.map((obj) =>
+        this.parseProperty(Utilities.getJoiLabel(obj.schema), obj.schema, property, parameterType, useDefinitions, false)
+      );
       delete property.type;
     }
   }
@@ -638,12 +640,12 @@ internals.properties.prototype.parseAlternatives = function (property, joiObj, n
         property['x-alternatives'] = Hoek.clone(altArray);
       }
     } else {
-      property.anyOf = buildAlternativesArray(
-        joiObj.$_terms.matches.reduce((res, obj) => {
-          obj.then && res.push(obj.then);
-          obj.otherwise && res.push(obj.otherwise);
-          return res;
-        }, [])
+      property.anyOf = joiObj.$_terms.matches.reduce((res, obj) => {
+        obj.then && res.push(obj.then);
+        obj.otherwise && res.push(obj.otherwise);
+        return res;
+      }, []).map((obj) =>
+        this.parseProperty(Utilities.getJoiLabel(obj), obj, property, parameterType, useDefinitions, false)
       );
       delete property.type;
     }


### PR DESCRIPTION
There is no need to use `x-alt-definitions` with OpenAPI v3. We can add the schemas normally which means they will be properly referenced by the endpoints.