### PR TITLE
Better handling of alternatives for openapi v3

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -584,13 +584,13 @@ internals.properties.prototype.parseArray = function (property, joiObj, name, pa
  * @return {Object}
  */
 internals.properties.prototype.parseAlternatives = function (property, joiObj, name, parameterType, useDefinitions) {
-  const buildAlternativesArray = (schemas) => {
+  const buildAlternativesArray = (schemas, isAlt = true) => {
     return schemas
       .map((schema) => {
         const childMetaName = Utilities.getJoiMetaProperty(schema, 'swaggerLabel');
         const altName = childMetaName || Utilities.getJoiLabel(schema) || name;
         //name, joiObj, parent, parameterType, useDefinitions, isAlt
-        return this.parseProperty(altName, schema, property, parameterType, useDefinitions, true);
+        return this.parseProperty(altName, schema, property, parameterType, useDefinitions, isAlt);
       })
       .filter((obj) => obj);
   };
@@ -611,7 +611,10 @@ internals.properties.prototype.parseAlternatives = function (property, joiObj, n
         property['x-alternatives'] = Hoek.clone(altArray);
       }
     } else {
-      property.anyOf = buildAlternativesArray(joiObj.$_terms.matches.map((obj) => obj.schema));
+      property.anyOf = buildAlternativesArray(
+        joiObj.$_terms.matches.map((obj) => obj.schema),
+        false
+      );
       delete property.type;
     }
   }
@@ -643,7 +646,8 @@ internals.properties.prototype.parseAlternatives = function (property, joiObj, n
           obj.then && res.push(obj.then);
           obj.otherwise && res.push(obj.otherwise);
           return res;
-        }, [])
+        }, []),
+        false
       );
       delete property.type;
     }

--- a/test/Integration/alternatives-test.js
+++ b/test/Integration/alternatives-test.js
@@ -412,10 +412,10 @@ lab.experiment('alternatives', () => {
           schema: {
             anyOf: [
               {
-                $ref: '#/x-alt-definitions/alternative1'
+                $ref: '#/components/schemas/alternative1'
               },
               {
-                $ref: '#/x-alt-definitions/alternative2'
+                $ref: '#/components/schemas/alternative2'
               }
             ]
           }
@@ -429,10 +429,10 @@ lab.experiment('alternatives', () => {
             schema: {
               anyOf: [
                 {
-                  $ref: '#/x-alt-definitions/alternative1'
+                  $ref: '#/components/schemas/alternative1'
                 },
                 {
-                  $ref: '#/x-alt-definitions/alternative2'
+                  $ref: '#/components/schemas/alternative2'
                 }
               ]
             }
@@ -446,7 +446,7 @@ lab.experiment('alternatives', () => {
       content: {
         'application/json': {
           schema: {
-            $ref: '#/components/schemas/Model1'
+            $ref: '#/components/schemas/Model2'
           }
         }
       }
@@ -454,15 +454,15 @@ lab.experiment('alternatives', () => {
 
     expect(response.result.components.schemas).to.equal({
       Type: { type: 'string', enum: ['string', 'number', 'image'] },
-      Model1: {
+      Model2: {
         type: 'object',
         properties: {
           type: { $ref: '#/components/schemas/Type' },
           data: { anyOf: [{ type: 'string' }, { type: 'number' }, { type: 'string', 'x-format': { uri: true } }] },
-          extra: { anyOf: [{ $ref: '#/x-alt-definitions/Dimensions' }] }
+          extra: { anyOf: [{ $ref: '#/components/schemas/Dimensions' }] }
         }
       },
-      Model2: {
+      Model3: {
         type: 'object',
         properties: {
           type: { $ref: '#/components/schemas/Type' },
@@ -476,12 +476,9 @@ lab.experiment('alternatives', () => {
               { type: 'string', 'x-format': { uri: true } }
             ]
           },
-          extra: { anyOf: [{ $ref: '#/x-alt-definitions/Extra' }] }
+          extra: { anyOf: [{ $ref: '#/components/schemas/Extra' }] }
         }
-      }
-    });
-
-    expect(response.result['x-alt-definitions']).to.equal({
+      },
       alternative1: {
         type: 'object',
         properties: { name: { type: 'string' } },
@@ -511,6 +508,8 @@ lab.experiment('alternatives', () => {
         required: ['name']
       }
     });
+
+    expect(response.result['x-alt-definitions']).to.be.undefined();
 
     // test full swagger document
     const isValid = await Validate.test(response.result);


### PR DESCRIPTION
There is no need to use x-alt-definitions with OpenAPI v3. We can add the schemas normally which means they will be properly referenced by the endpoints.