### PR TITLE
Retain components.securitySchemes when deReference is enabled in OAS v3

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -27,7 +27,9 @@ builder.default = {
 
 internals.openapiBaseSchema = Joi.object({
   info: Joi.any(),
-  schemes: Joi.array().items(Joi.string().valid('http', 'https', 'ws', 'wss')).optional(),
+  schemes: Joi.array()
+    .items(Joi.string().valid('http', 'https', 'ws', 'wss'))
+    .optional(),
   consumes: Joi.array().items(Joi.string()),
   produces: Joi.array().items(Joi.string()),
   paths: Joi.any(),
@@ -183,7 +185,11 @@ builder.dereference = async (schema) => {
     const json = await JSONDeRef.dereference(schema);
 
     if (schema.openapi === '3.0.0') {
-      delete json.components;
+      for (const key of Object.keys(json.components)) {
+        if (key !== 'securitySchemes') {
+          delete json.components[key];
+        }
+      }
     } else {
       delete json.definitions;
     }

--- a/test/Integration/dereference-test.js
+++ b/test/Integration/dereference-test.js
@@ -60,12 +60,23 @@ lab.experiment('dereference', () => {
   });
 
   lab.test('flatten with no references on OAS v3', async () => {
-    const server = await Helper.createServer({ deReference: true, OAS: 'v3.0' }, routes);
+    const swaggerOptions = {
+      deReference: true,
+      OAS: 'v3.0',
+      securityDefinitions: {
+        jwt: {
+          type: 'apiKey',
+          name: 'Authorization',
+          in: 'header'
+        }
+      }
+    };
+    const server = await Helper.createServer(swaggerOptions, routes);
     const response = await server.inject({ method: 'GET', url: '/openapi.json' });
-    expect(response.result.components).not.exists();
+    expect(response.result.components).to.equal({ securitySchemes: swaggerOptions.securityDefinitions });
     expect(response.statusCode).to.equal(200);
     expect(response.result.paths['/store/'].post.requestBody.content).to.equal({
-      "application/json": {
+      'application/json': {
         schema: {
           properties: {
             a: {


### PR DESCRIPTION
See https://github.com/hapi-swagger/hapi-swagger/pull/884#issuecomment-2164141354